### PR TITLE
Update kubeconfig to always use dns hostname for server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Modify kubeconfig of workload clusters to use DNS hostname of server if an IP address is found (required for CAPG clusters)
+
 ## [0.0.1] - 2023-03-16
 
 - Added initial framework layout

--- a/framework.go
+++ b/framework.go
@@ -149,7 +149,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 		return err
 	}
 
-	// Remove the finalizer from the bastion secret or the namespace delete gets blocked
+	// Remove the finalizer from the bastion secret (if it exists) or the namespace delete gets blocked
 	err = f.MC().Client.Patch(ctx,
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -159,7 +159,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 		},
 		cr.RawPatch(types.MergePatchType, []byte(`{"metadata":{"finalizers":null}}`)),
 	)
-	if err != nil {
+	if cr.IgnoreNotFound(err) != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.14.5
 	sigs.k8s.io/e2e-framework v0.1.0
 	sigs.k8s.io/kind v0.17.0
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -88,5 +89,4 @@ require (
 	k8s.io/utils v0.0.0-20230115233650-391b47cb4029 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )


### PR DESCRIPTION
CAPG clusters have their kubeconfig generated using the IP address of the GCP load balancer but this isn't routable over our VPN so results in failure when running locally. This change ensure that any kubeconfig found to be using the IP address hostname is instead changed to use the DNS name built up from the `baseDomain` for the cluster.