### PR TITLE
Support multiple context in MC kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ability to use an MC kubeconfig with multiple contexts and switch between them
 
+### Removed
+
+- Removed `NewWithKubeconfig` function in favour of always using the env var for the path.
+
 ## [0.0.4] - 2023-03-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to use an MC kubeconfig with multiple contexts and switch between them
+
 ## [0.0.4] - 2023-03-24
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Documentation can be found at: [pkg.go.dev/github.com/giantswarm/clustertest](ht
 ```go
 ctx := context.Background()
 
-framework, err := clustertest.New()
+framework, err := clustertest.New("capa_standard")
 if err != nil {
   panic(err)
 }

--- a/doc.go
+++ b/doc.go
@@ -6,7 +6,7 @@
 //
 //	ctx := context.Background()
 //
-//	framework, err := clustertest.New()
+//	framework, err := clustertest.New("context_name")
 //	if err != nil {
 //		panic(err)
 //	}
@@ -28,7 +28,7 @@
 //		var err error
 //		ctx := context.Background()
 //
-//		framework, err = clustertest.New()
+//		framework, err = clustertest.New("context_name")
 //		if err != nil {
 //			panic(err)
 //		}

--- a/framework.go
+++ b/framework.go
@@ -58,6 +58,18 @@ func NewWithKubeconfig(kubeconfigPath string) (*Framework, error) {
 	}, nil
 }
 
+// UseContext changes the current context of the MC client to the provided name
+func (f *Framework) UseContext(contextName string) error {
+	mcClient, err := client.NewWithContext(f.mcKubeconfigPath, contextName)
+	if err != nil {
+		return err
+	}
+
+	f.mcClient = mcClient
+
+	return nil
+}
+
 // MC returns an initialized client for the Management Cluster
 func (f *Framework) MC() *client.Client {
 	return f.mcClient

--- a/framework.go
+++ b/framework.go
@@ -32,33 +32,27 @@ type Framework struct {
 	wcClients        map[string]*client.Client
 }
 
-// New initializes a new Framework instance using the kubeconfig found in the env var `E2E_KUBECONFIG`
-func New() (*Framework, error) {
+// New initializes a new Framework instance using the provided context from the kubeconfig found in the env var `E2E_KUBECONFIG`
+func New(contextName string) (*Framework, error) {
 	mcKubeconfig, ok := os.LookupEnv(KubeconfigEnvVar)
 	if !ok {
 		return nil, fmt.Errorf("no %s set", KubeconfigEnvVar)
 	}
 
-	framework, err := NewWithKubeconfig(mcKubeconfig)
-
-	return framework, err
-}
-
-// NewWithKubeconfig generates a new framework initialised with the Management Cluster provided as a Kubeconfig
-func NewWithKubeconfig(kubeconfigPath string) (*Framework, error) {
-	mcClient, err := client.New(kubeconfigPath)
+	mcClient, err := client.NewWithContext(mcKubeconfig, contextName)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Framework{
-		mcKubeconfigPath: kubeconfigPath,
+		mcKubeconfigPath: mcKubeconfig,
 		mcClient:         mcClient,
 		wcClients:        map[string]*client.Client{},
 	}, nil
 }
 
-// UseContext changes the current context of the MC client to the provided name
+// UseContext changes the current context of the MC client to the provided name.
+// A context matching the given name must exist in the MCs kubeconfig file.
 func (f *Framework) UseContext(contextName string) error {
 	mcClient, err := client.NewWithContext(f.mcKubeconfigPath, contextName)
 	if err != nil {

--- a/framework.go
+++ b/framework.go
@@ -51,19 +51,6 @@ func New(contextName string) (*Framework, error) {
 	}, nil
 }
 
-// UseContext changes the current context of the MC client to the provided name.
-// A context matching the given name must exist in the MCs kubeconfig file.
-func (f *Framework) UseContext(contextName string) error {
-	mcClient, err := client.NewWithContext(f.mcKubeconfigPath, contextName)
-	if err != nil {
-		return err
-	}
-
-	f.mcClient = mcClient
-
-	return nil
-}
-
 // MC returns an initialized client for the Management Cluster
 func (f *Framework) MC() *client.Client {
 	return f.mcClient


### PR DESCRIPTION
This allows for providing a single Kubeconfig for use by the framework that contains different context. This can be used for having multiple MCs in a single kubeconfig and have the test suites switch to the appropriate context (MC) for their tests.

My thinking here is there will be a kubeconfig provided to the test suites that contain context such as `capa`, `capvcd`, etc. which would allow for running the entire collection of test suites together.