### PR TITLE
Enable overriding app version with env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to override App version from environment variable
+
 ## [0.0.5] - 2023-03-27
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ go get github.com/giantswarm/clustertest
 - Wrapper types around Cluster apps (and their default-apps)
 - Management (creation and deletion) or Organization resources
 - Wait and polling helpers
+- Override App versions using environment variables. (See [`application` documentation](https://pkg.go.dev/github.com/giantswarm/clustertest/pkg/application) for details)
 
 ## Documentation
 

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"os"
 	"path"
 	"strings"
 	"testing"
@@ -141,5 +142,40 @@ func TestMustWithValuesFile(t *testing.T) {
 
 	if v, ok := cm.Data["values"]; !ok || v == "" {
 		t.Fatal("Was expecting ConfigMap to have a populated values key in the data")
+	}
+}
+
+func TestWithVersion_Override(t *testing.T) {
+	overrideVersion := "v9.9.9"
+	os.Setenv("E2E_OVERRIDE_CLUSTER_AWS", overrideVersion)
+
+	// Test successful override
+	app, _, err := New("installName", "cluster-aws").WithVersion("").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version != overrideVersion {
+		t.Errorf("Was expecting version to be overridden. Expected: %s, Actual: %s", overrideVersion, app.Spec.Version)
+	}
+
+	// Test specified version
+	app, _, err = New("installName", "cluster-aws").WithVersion("v1.2.3").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version == overrideVersion {
+		t.Errorf("Was not expecting version to be overridden. Expected: %s, Actual: %s", "v1.2.3", app.Spec.Version)
+	}
+
+	// Test latest version
+	app, _, err = New("installName", "cluster-aws").WithVersion("latest").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version == overrideVersion {
+		t.Errorf("Was not expecting version to be overridden. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
 	}
 }

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -2,7 +2,6 @@ package application
 
 import (
 	"fmt"
-	"regexp"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -30,9 +29,6 @@ const (
 	ProviderOpenStack     Provider = "openstack"
 	ProviderVSphere       Provider = "vsphere"
 )
-
-// If commit SHA based version we'll change the catalog
-var isShaVersion = regexp.MustCompile(`(?m)^v?[0-9]+\.[0-9]+\.[0-9]+\-\w{40}`)
 
 // NewClusterApp generates a new Cluster object to handle creation of Cluster related apps
 func NewClusterApp(clusterName string, provider Provider) *Cluster {
@@ -68,22 +64,17 @@ func (c *Cluster) WithNamespace(namespace string) *Cluster {
 
 // WithAppVersions sets the Version values
 //
-// If the versions are specified as empty string (the default) or the value "latest" then
-// the version will be fetched from the latest release on GitHub.
+// If the versions are set to the value `latest` then the version will be fetched from
+// the latest release on GitHub.
+// If set to an empty string (the default) then the environment variables
+// will first be checked for a matching override var and if not found then
+// the logic will fall back to the same as `latest`.
 //
 // If the version provided is suffixed with a commit sha then the `Catalog` use for the Apps
 // will be updated to `cluster-test`.
 func (c *Cluster) WithAppVersions(clusterVersion string, defaultAppsVersion string) *Cluster {
 	c.ClusterApp = c.ClusterApp.WithVersion(clusterVersion)
-	if isShaVersion.MatchString(clusterVersion) {
-		c.ClusterApp = c.ClusterApp.WithCatalog("cluster-test")
-	}
-
 	c.DefaultAppsApp = c.DefaultAppsApp.WithVersion(defaultAppsVersion)
-	if isShaVersion.MatchString(defaultAppsVersion) {
-		c.DefaultAppsApp = c.DefaultAppsApp.WithCatalog("cluster-test")
-	}
-
 	return c
 }
 

--- a/pkg/application/doc.go
+++ b/pkg/application/doc.go
@@ -20,4 +20,31 @@
 //		WithAppValuesFile(path.Clean("./test_data/cluster_values.yaml"), path.Clean("./test_data/default-apps_values.yaml"))
 //
 //	clusterApp, clusterConfigMap, defaultAppsApp, defaultAppsConfigMap, err := cluster.Build()
+//
+// # App Versions
+//
+// When specifing the App version there are a couple special cases that you can take advantage of:
+//  1. Using the value `latest` as the App version will cause the latest released version found on GitHub to be used.
+//  2. Setting the version to an empty string will allow for overriding the version from an environment variable.
+//     If an environment variable is found with the prefix `E2E_OVERRIDE_` followed by an uppercase version of the app
+//     name (with dashes replaced with underscored) then that value will be used. If no such environemnt variable is
+//     found then it will fallback to the same logic as `latest` above.
+//
+// E.g. To override the `cluster-aws` app version the environment variable `E2E_OVERRIDE_CLUSTER_AWS` should be used.
+//
+// Combining these two features together allows for creating scenarios that test upgrading an App from the current latest
+// to the version being worked on in a PR.
+//
+// Example:
+//
+// Assuming the `E2E_OVERRIDE_CLUSTER_AWS` env var is set to a valid version then the following will install cluster-aws
+// as the lastest released version then later install (upgrade) again with the version overridden from the environment variable.
+//
+//	appCR, configMap, err := application.New("upgrade-test", "cluster-aws").WithVersion("latest").Build()
+//
+//	// ... apply manifests and wait for install to complete...
+//
+//	appCR, configMap, err = application.New("upgrade-test", "cluster-aws").WithVersion("").Build()
+//
+//	// ... apply manifests and wait for upgrade to complete...
 package application


### PR DESCRIPTION
Slightly tweak the App version logic to support overriding the version from an environment variable when set to `""` (empty string).

The env var name must match a specific format consisting of a standard prefix and a modification of the app name, E.g. for `cluster-aws` the env var would be `E2E_OVERRIDE_CLUSTER_AWS` and if none is found then the same logic as `latest` is used.