### PR TITLE
Change version override to use a single env var

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -3,6 +3,8 @@ CVE-2022-36129 until=2023-06-30
 
 # github.com/opencontainers/runc@v1.1.2
 CVE-2023-27561 until=2023-06-30
+CVE-2023-28642 until=2023-06-30
+CVE-2023-25809 until=2023-06-30
 
 # k8s.io/apiserver@v0.26.1
 sonatype-2022-6522 until=2023-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Version override values are now provided using a single env var (`E2E_OVERRIDE_VERSIONS`)
+
 ## [0.0.6] - 2023-03-28
 
 ### Added

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -1,6 +1,7 @@
 package application
 
 import (
+	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -147,7 +148,7 @@ func TestMustWithValuesFile(t *testing.T) {
 
 func TestWithVersion_Override(t *testing.T) {
 	overrideVersion := "v9.9.9"
-	os.Setenv("E2E_OVERRIDE_CLUSTER_AWS", overrideVersion)
+	os.Setenv("E2E_OVERRIDE_VERSIONS", fmt.Sprintf("cluster-aws=%s", overrideVersion))
 
 	// Test successful override
 	app, _, err := New("installName", "cluster-aws").WithVersion("").Build()

--- a/pkg/application/doc.go
+++ b/pkg/application/doc.go
@@ -26,18 +26,16 @@
 // When specifing the App version there are a couple special cases that you can take advantage of:
 //  1. Using the value `latest` as the App version will cause the latest released version found on GitHub to be used.
 //  2. Setting the version to an empty string will allow for overriding the version from an environment variable.
-//     If an environment variable is found with the prefix `E2E_OVERRIDE_` followed by an uppercase version of the app
-//     name (with dashes replaced with underscored) then that value will be used. If no such environemnt variable is
-//     found then it will fallback to the same logic as `latest` above.
-//
-// E.g. To override the `cluster-aws` app version the environment variable `E2E_OVERRIDE_CLUSTER_AWS` should be used.
+//     The environment variable `E2E_OVERRIDE_VERSIONS` can be used to provide a comma seperated list of app version
+//     overrides in the format `app-name=version` (e.g. `cluster-aws=v1.2.3,cluster-gcp=v1.2.3-2hehdu`). If no such
+//     environemnt variable is found then it will fallback to the same logic as `latest` above.
 //
 // Combining these two features together allows for creating scenarios that test upgrading an App from the current latest
 // to the version being worked on in a PR.
 //
 // Example:
 //
-// Assuming the `E2E_OVERRIDE_CLUSTER_AWS` env var is set to a valid version then the following will install cluster-aws
+// Assuming the `E2E_OVERRIDE_VERSIONS` env var is set to override cluster-aws with a valid version then the following will install cluster-aws
 // as the lastest released version then later install (upgrade) again with the version overridden from the environment variable.
 //
 //	appCR, configMap, err := application.New("upgrade-test", "cluster-aws").WithVersion("latest").Build()

--- a/pkg/application/utils.go
+++ b/pkg/application/utils.go
@@ -3,6 +3,7 @@ package application
 import (
 	"bytes"
 	"os"
+	"strings"
 	"text/template"
 )
 
@@ -45,4 +46,28 @@ func parseTemplate(manifest string, config *ValuesTemplateVars) string {
 	_ = ut.Execute(manifestBuffer, *config)
 
 	return manifestBuffer.String()
+}
+
+const VersionOverrideEnvPrefix = "E2E_OVERRIDE_VERSIONS"
+
+func getOverrideVersions() map[string]string {
+	versions := map[string]string{}
+
+	overrides := os.Getenv(VersionOverrideEnvPrefix)
+	if overrides != "" {
+		overridesList := strings.Split(overrides, ",")
+		for _, pair := range overridesList {
+			parts := strings.Split(pair, "=")
+			if len(parts) == 2 {
+				versions[strings.TrimSpace(strings.ToLower(parts[0]))] = strings.TrimSpace(parts[1])
+			}
+		}
+	}
+
+	return versions
+}
+
+func getOverrideVersion(app string) (string, bool) {
+	ver := getOverrideVersions()[strings.ToLower(app)]
+	return ver, ver != ""
 }


### PR DESCRIPTION
Unfortunately Tekton doesn't allow for dynamically setting the name property of an env var in a pod so we need to have a static, known name to use for overriding.

The added benefit of this is it's easier / cleaner from a CI/CD perspective to provide multiple overrides in a single run.