### PR TITLE
Add LoadCluster function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `LoadCluster` function. This will return a Cluster object constructed
+  from an existing WC on the targeted MC (using the cluster and default-apps
+  App CRs). The cluster is specified with the `E2E_WC_NAME` and
+  `E2E_WC_NAMESPACE` env vars. It returns nil if they are not set.
+
 ## [0.0.7] - 2023-03-31
 
 ### Changed

--- a/doc.go
+++ b/doc.go
@@ -21,6 +21,27 @@
 //	// Run tests...
 //
 //	err = framework.DeleteCluster(ctx, cluster)
+
+// # Example using an existing Workload Cluster
+//
+//	ctx := context.Background()
+//
+//	framework, err := clustertest.New("context_name")
+//	if err != nil {
+//		panic(err)
+//	}
+//
+//	// The E2E_WC_NAME and E2E_WC_NAMESPACE env vars must be exported
+//	cluster, err := framework.LoadCluster()
+//	if err != nil {
+//		panic(err)
+//	}
+//	if cluster == nil {
+//		// Handle the case where the env vars aren't provided
+//	}
+//
+//	// Run tests...
+//	// No need to clean up as the user is responsible for the cluster
 //
 // # Example Using Ginkgo
 //

--- a/framework.go
+++ b/framework.go
@@ -93,13 +93,13 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 		return nil, nil
 	}
 
-	clusterApp, clusterValues, err := f.getAppAndValues(name, namespace)
+	clusterApp, clusterValues, err := f.GetAppAndValues(name, namespace)
 	if err != nil {
 		return nil, err
 	}
 
 	defaultAppsName := fmt.Sprintf("%s-default-apps", name)
-	defaultApps, defaultAppsValues, err := f.getAppAndValues(defaultAppsName, namespace)
+	defaultApps, defaultAppsValues, err := f.GetAppAndValues(defaultAppsName, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +311,9 @@ func (f *Framework) DeleteOrg(ctx context.Context, org *organization.Org) error 
 	return nil
 }
 
-func (f *Framework) getAppAndValues(name, namespace string) (*applicationv1alpha1.App, *corev1.ConfigMap, error) {
+// GetAppAndValues will return the specified App CR and uservalues ConfigMap
+// from the Management Cluster
+func (f *Framework) GetAppAndValues(name, namespace string) (*applicationv1alpha1.App, *corev1.ConfigMap, error) {
 	ctx := context.Background()
 
 	app := &applicationv1alpha1.App{}

--- a/framework.go
+++ b/framework.go
@@ -68,6 +68,23 @@ func (f *Framework) WC(clusterName string) (*client.Client, error) {
 	return c, nil
 }
 
+// LoadCluster will construct a Cluster struct using a Workload Cluster's
+// cluster and default-apps App CRs on the targeted Management Cluster. The
+// name and namespace where the cluster are installed need to be provided with
+// the E2E_WC_NAME and E2E_WC_NAMESPACE env vars.
+//
+// If one of the env vars are not set, a nil Cluster and error will be
+// returned.
+//
+// Example:
+//
+//	cluster, err := framework.LoadCluster()
+//	if err != nil {
+//		// handle error
+//	}
+//	if cluster == nil {
+//		// handle cluster not provided
+//	}
 func (f *Framework) LoadCluster() (*application.Cluster, error) {
 	name := os.Getenv(EnvWorkloadClusterName)
 	namespace := os.Getenv(EnvWorkloadClusterNamespace)
@@ -128,38 +145,6 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 			Name: namespace,
 		},
 	}, nil
-}
-
-func (f *Framework) getAppAndValues(name, namespace string) (*applicationv1alpha1.App, *corev1.ConfigMap, error) {
-	ctx := context.Background()
-
-	app := &applicationv1alpha1.App{}
-	err := f.mcClient.Get(
-		ctx,
-		types.NamespacedName{
-			Name:      name,
-			Namespace: namespace,
-		},
-		app,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	values := &corev1.ConfigMap{}
-	err = f.mcClient.Get(
-		ctx,
-		types.NamespacedName{
-			Name:      app.Spec.UserConfig.ConfigMap.Name,
-			Namespace: app.Spec.UserConfig.ConfigMap.Namespace,
-		},
-		values,
-	)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return app, values, nil
 }
 
 // ApplyCluster takes a Cluster object, applies it to the MC in the correct order and then waits for a valid Kubeconfig to be available
@@ -324,4 +309,36 @@ func (f *Framework) DeleteOrg(ctx context.Context, org *organization.Org) error 
 	}
 
 	return nil
+}
+
+func (f *Framework) getAppAndValues(name, namespace string) (*applicationv1alpha1.App, *corev1.ConfigMap, error) {
+	ctx := context.Background()
+
+	app := &applicationv1alpha1.App{}
+	err := f.mcClient.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      name,
+			Namespace: namespace,
+		},
+		app,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	values := &corev1.ConfigMap{}
+	err = f.mcClient.Get(
+		ctx,
+		types.NamespacedName{
+			Name:      app.Spec.UserConfig.ConfigMap.Name,
+			Namespace: app.Spec.UserConfig.ConfigMap.Namespace,
+		},
+		values,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return app, values, nil
 }

--- a/framework.go
+++ b/framework.go
@@ -73,7 +73,7 @@ func (f *Framework) WC(clusterName string) (*client.Client, error) {
 // name and namespace where the cluster are installed need to be provided with
 // the E2E_WC_NAME and E2E_WC_NAMESPACE env vars.
 //
-// If one of the env vars are not set, a nil Cluster and error will be
+// If one of the env vars are not set, a nil Cluster and nil error will be
 // returned.
 //
 // Example:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26378

This lets the caller to load a WC from the targeted MC. This is done by setting the `E2E_WC_NAME` and `E2E_WC_NAMESPACE` env vars. The framework will get the App and values ConfigMap and set up and return the Cluster struct. 