### PR TITLE
User config secret name of cluster app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# IDE
+.vscode/
+.idea/*
+

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -24,13 +24,14 @@ func init() {
 
 // Application contains all details for creating an App and its values ConfigMap
 type Application struct {
-	InstallName string
-	AppName     string
-	Version     string
-	Catalog     string
-	Values      string
-	InCluster   bool
-	Namespace   string
+	InstallName          string
+	AppName              string
+	Version              string
+	Catalog              string
+	Values               string
+	InCluster            bool
+	Namespace            string
+	UserConfigSecretName string
 
 	AppLabels       map[string]string
 	ConfigMapLabels map[string]string
@@ -131,6 +132,12 @@ func (a *Application) WithConfigMapLabels(labels map[string]string) *Application
 	return a
 }
 
+// WithUserConfigSecretName sets the provided name of the secret as UserConfigSecretName
+func (a *Application) WithUserConfigSecretName(name string) *Application {
+	a.UserConfigSecretName = name
+	return a
+}
+
 // Build generates the App and ConfigMap resources
 func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, error) {
 	switch a.Version {
@@ -167,6 +174,7 @@ func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, erro
 		InCluster:               a.InCluster,
 		Namespace:               a.Namespace,
 		UserConfigConfigMapName: fmt.Sprintf("%s-userconfig", a.InstallName),
+		UserConfigSecretName:    a.UserConfigSecretName,
 		Version:                 a.Version,
 	})
 	if err != nil {

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -106,6 +106,12 @@ func (c *Cluster) WithAppValuesFile(clusterValuesFile string, defaultAppsValuesF
 	return c
 }
 
+// WithUserConfigSecret sets the name of the referenced Secret under userConfig section
+func (c *Cluster) WithUserConfigSecret(secretName string) *Cluster {
+	c.ClusterApp = c.ClusterApp.WithUserConfigSecretName(secretName)
+	return c
+}
+
 // Build defaults and populates some required values on the apps then generated the App and Configmap pairs for both the
 // cluster and default-apps apps.
 func (c *Cluster) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, *applicationv1alpha1.App, *corev1.ConfigMap, error) {


### PR DESCRIPTION
because the cluster App cr for vsphere looks like this:

```
apiVersion: application.giantswarm.io/v1alpha1
kind: App
metadata:
  labels:
    app-operator.giantswarm.io/version: 0.0.0
    app.kubernetes.io/name: cluster-vsphere
  name: $CLUSTER
  namespace: org-giantswarm
spec:
  catalog: cluster-test
  extraConfigs:
  - kind: secret
    name: container-registries-configuration
    namespace: giantswarm
    priority: 25
  kubeConfig:
    inCluster: true
  name: cluster-vsphere
  namespace: org-giantswarm
  userConfig:
    configMap:
      name: $CLUSTER-user-values
      namespace: org-giantswarm
    secret:
      name: vsphere-credentials
      namespace: org-giantswarm
  version: 0.3.1-689cef7898e90f8184ac526369dddf119d9a0af2
```

so we need a way to change the 

```
...
    secret:
      name: vsphere-credentials
...
```
chunk