### PR TITLE
Wait for org delete to complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Wait for successful Org deletion when deleting cluster
+
 ## [0.0.10] - 2023-05-10
 
 ### Added
@@ -19,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `Consistently` function. This takes in a function that returns an error and 
+- Add `Consistently` function. This takes in a function that returns an error and
   runs it for a specified period, stopping on the first error.
 
 ## [0.0.8] - 2023-04-13

--- a/framework.go
+++ b/framework.go
@@ -304,7 +304,15 @@ func (f *Framework) DeleteOrg(ctx context.Context, org *organization.Org) error 
 	}
 
 	if organization.SafeToDelete(*orgCR) {
-		return f.MC().Client.Delete(ctx, orgCR, &cr.DeleteOptions{})
+		err = f.MC().Client.Delete(ctx, orgCR, &cr.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+
+		err = wait.For(wait.IsResourceDeleted(ctx, f.MC(), orgCR), wait.WithContext(ctx))
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26823

Ensure that the Org and all other resources associated with the E2E test run are cleaned up before completing.

Note: This change will likely increase the amount of false failures we see.