### PR TITLE
Include resource kind in wait log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved log message when waiting for resource to be created/deleted so that it includes the kind of resource being waited for
+
 ## [0.0.16] - 2023-07-11
 
 ### Added

--- a/pkg/wait/conditions.go
+++ b/pkg/wait/conditions.go
@@ -83,7 +83,7 @@ func IsClusterReadyCondition(ctx context.Context, kubeClient *client.Client, clu
 // IsResourceDeleted returns a WaitCondition that checks if the given resource has been deleted from the cluster yet
 func IsResourceDeleted(ctx context.Context, kubeClient *client.Client, resource cr.Object) WaitCondition {
 	return func() (bool, error) {
-		logger.Log("Checking if resource '%s' still exists", resource.GetName())
+		logger.Log("Checking if %s '%s' still exists", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName())
 		err := kubeClient.Client.Get(ctx, cr.ObjectKeyFromObject(resource), resource, &cr.GetOptions{})
 		if cr.IgnoreNotFound(err) != nil {
 			return false, err
@@ -99,7 +99,7 @@ func IsResourceDeleted(ctx context.Context, kubeClient *client.Client, resource 
 func DoesResourceExist(ctx context.Context, kubeClient *client.Client, resource cr.Object) WaitCondition {
 	return func() (bool, error) {
 		if err := kubeClient.Client.Get(ctx, cr.ObjectKeyFromObject(resource), resource); err != nil {
-			logger.Log("Waiting for resource '%s' to be created", resource.GetName())
+			logger.Log("Waiting for %s '%s' to be created", resource.GetObjectKind().GroupVersionKind().Kind, resource.GetName())
 			return false, nil
 		}
 


### PR DESCRIPTION
Rather than something like `Checking if resource 't-vwbnapj' still exists` that could be either the Cluster or the Organization, this change updates the log message to use the resources 'Kind' rather than just `resource` to make it clear which resource we're waiting for.