### PR TITLE
Support GITHUB_TOKEN_FILE env var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support a `GITHUB_TOKEN_FILE` environment variable that points to a file location containing the GitHub token
+
 ## [0.1.0] - 2023-07-27
 
 ### Added

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"regexp"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -16,6 +15,8 @@ import (
 	"github.com/google/go-github/v53/github"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
+
+	"github.com/giantswarm/clustertest/pkg/utils"
 )
 
 // If commit SHA based version we'll change the catalog
@@ -166,9 +167,10 @@ func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, erro
 	case "latest":
 		ctx := context.Background()
 		var ghHTTPClient *http.Client
-		if os.Getenv("GITHUB_TOKEN") != "" {
+		githubToken := utils.GetGitHubToken()
+		if githubToken != "" {
 			ghHTTPClient = oauth2.NewClient(ctx, oauth2.StaticTokenSource(
-				&oauth2.Token{AccessToken: os.Getenv("GITHUB_TOKEN")},
+				&oauth2.Token{AccessToken: githubToken},
 			))
 		}
 		gh := github.NewClient(ghHTTPClient)

--- a/pkg/utils/github.go
+++ b/pkg/utils/github.go
@@ -1,0 +1,24 @@
+package utils
+
+import (
+	"os"
+	"strings"
+)
+
+func GetGitHubToken() string {
+	envToken := strings.TrimSpace(os.Getenv("GITHUB_TOKEN"))
+	if envToken != "" {
+		return envToken
+	}
+
+	tokenLocation := strings.TrimSpace(os.Getenv("GITHUB_TOKEN_FILE"))
+	if tokenLocation != "" {
+		token, err := os.ReadFile(tokenLocation)
+		if err != nil {
+			return ""
+		}
+		return string(token)
+	}
+
+	return ""
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/27743

Adds support for a `GITHUB_TOKEN_FILE` environment variable so its possible to mount a secret containing the GitHub token as a volume that can be updated when the access token is renewed.

The support for the `GITHUB_TOKEN` environment variable still takes precedence if set.