### PR TITLE
Allow to set application organization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode/
 .idea/*
 
+clustertest*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow setting the `Organization` when modeling an `Application`, as that's what will be used by `kubectl-gs` to determine the app namespace.
+
 ## [0.2.0] - 2023-08-17
 
 - Support passing additional template values to Application. This changes the signature of `WithValues` and `WithValuesFile` when creating ClusterApps.

--- a/framework.go
+++ b/framework.go
@@ -88,6 +88,7 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 	ctx := context.Background()
 	name := os.Getenv(EnvWorkloadClusterName)
 	namespace := os.Getenv(EnvWorkloadClusterNamespace)
+	org := organization.NewFromNamespace(namespace)
 
 	if name == "" || namespace == "" {
 		return nil, nil
@@ -126,7 +127,7 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 			Catalog:         clusterApp.Spec.Catalog,
 			Values:          clusterValues.Data["values"],
 			InCluster:       clusterApp.Spec.KubeConfig.InCluster,
-			Namespace:       namespace,
+			Organization:    *org,
 			AppLabels:       clusterApp.Labels,
 			ConfigMapLabels: clusterValues.Labels,
 		},
@@ -137,13 +138,11 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 			Catalog:         defaultApps.Spec.Catalog,
 			Values:          defaultAppsValues.Data["values"],
 			InCluster:       defaultApps.Spec.KubeConfig.InCluster,
-			Namespace:       namespace,
+			Organization:    *org,
 			AppLabels:       defaultApps.Labels,
 			ConfigMapLabels: defaultApps.Labels,
 		},
-		Organization: &organization.Org{
-			Name: namespace,
-		},
+		Organization: org,
 	}, nil
 }
 

--- a/framework.go
+++ b/framework.go
@@ -118,8 +118,7 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 	f.wcClients[name] = wcClient
 
 	return &application.Cluster{
-		Name:      name,
-		Namespace: namespace,
+		Name: name,
 		ClusterApp: &application.Application{
 			InstallName:     clusterApp.Name,
 			AppName:         clusterApp.Spec.Name,
@@ -184,7 +183,7 @@ func (f *Framework) ApplyCluster(ctx context.Context, cluster *application.Clust
 		return nil, fmt.Errorf("failed to apply default-apps app CR: %v", err)
 	}
 
-	return f.WaitForClusterReady(ctx, cluster.Name, cluster.Namespace)
+	return f.WaitForClusterReady(ctx, cluster.Name, cluster.Organization.GetNamespace())
 }
 
 // WaitForClusterReady watches for a Kubeconfig secret to be created on the MC and then waits until that cluster's api-server response successfully
@@ -226,7 +225,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 	app := applicationv1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
-			Namespace: cluster.Namespace,
+			Namespace: cluster.Organization.GetNamespace(),
 		},
 	}
 	err := f.MC().Client.Delete(ctx, &app)
@@ -237,7 +236,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 	clusterResource := &capi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
-			Namespace: cluster.Namespace,
+			Namespace: cluster.Organization.GetNamespace(),
 		},
 	}
 	err = wait.For(wait.IsResourceDeleted(ctx, f.MC(), clusterResource), wait.WithContext(ctx))
@@ -250,7 +249,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-bastion-ignition", cluster.Name),
-				Namespace: cluster.Namespace,
+				Namespace: cluster.Organization.GetNamespace(),
 			},
 		},
 		cr.RawPatch(types.MergePatchType, []byte(`{"metadata":{"finalizers":null}}`)),

--- a/framework.go
+++ b/framework.go
@@ -183,7 +183,7 @@ func (f *Framework) ApplyCluster(ctx context.Context, cluster *application.Clust
 		return nil, fmt.Errorf("failed to apply default-apps app CR: %v", err)
 	}
 
-	return f.WaitForClusterReady(ctx, cluster.Name, cluster.Organization.GetNamespace())
+	return f.WaitForClusterReady(ctx, cluster.Name, cluster.GetNamespace())
 }
 
 // WaitForClusterReady watches for a Kubeconfig secret to be created on the MC and then waits until that cluster's api-server response successfully
@@ -225,7 +225,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 	app := applicationv1alpha1.App{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
-			Namespace: cluster.Organization.GetNamespace(),
+			Namespace: cluster.GetNamespace(),
 		},
 	}
 	err := f.MC().Client.Delete(ctx, &app)
@@ -236,7 +236,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 	clusterResource := &capi.Cluster{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cluster.Name,
-			Namespace: cluster.Organization.GetNamespace(),
+			Namespace: cluster.GetNamespace(),
 		},
 	}
 	err = wait.For(wait.IsResourceDeleted(ctx, f.MC(), clusterResource), wait.WithContext(ctx))
@@ -249,7 +249,7 @@ func (f *Framework) DeleteCluster(ctx context.Context, cluster *application.Clus
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      fmt.Sprintf("%s-bastion-ignition", cluster.Name),
-				Namespace: cluster.Organization.GetNamespace(),
+				Namespace: cluster.GetNamespace(),
 			},
 		},
 		cr.RawPatch(types.MergePatchType, []byte(`{"metadata":{"finalizers":null}}`)),

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -250,3 +250,8 @@ func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, erro
 
 	return app, configmap, nil
 }
+
+// GetNamespace returns the app namespace.
+func (a *Application) GetNamespace() string {
+	return a.Organization.GetNamespace()
+}

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -6,6 +6,8 @@ import (
 	"path"
 	"strings"
 	"testing"
+
+	"github.com/giantswarm/clustertest/pkg/organization"
 )
 
 func TestWithFunctions(t *testing.T) {
@@ -15,14 +17,14 @@ func TestWithFunctions(t *testing.T) {
 	catalog := "catalog"
 	values := "values"
 	inCluster := false
-	namespace := "namespace"
+	org := organization.New("giantswarm")
 
 	app := New(installName, appName).
 		WithVersion(version).
 		WithCatalog(catalog).
 		MustWithValues(values, nil).
 		WithInCluster(inCluster).
-		WithNamespace(namespace)
+		WithOrganization(*org)
 
 	if app.InstallName != installName {
 		t.Errorf("InstallName not as expected. Expected: %s, Actual: %s", installName, app.InstallName)
@@ -42,8 +44,30 @@ func TestWithFunctions(t *testing.T) {
 	if app.InCluster != inCluster {
 		t.Errorf("InCluster not as expected. Expected: %t, Actual: %t", inCluster, app.InCluster)
 	}
-	if app.Namespace != namespace {
-		t.Errorf("Namespace not as expected. Expected: %s, Actual: %s", namespace, app.Namespace)
+	if app.Organization.Name != org.Name {
+		t.Errorf("Organization not as expected. Expected: %s, Actual: %s", org.Name, app.Organization.Name)
+	}
+}
+
+func TestOrganizationNamespace(t *testing.T) {
+	installName := "installName"
+	appName := "appName"
+	version := "version"
+	values := "values"
+	org := organization.New("giantswarm")
+
+	app, _, err := New(installName, appName).
+		WithVersion(version).
+		MustWithValues(values, nil).
+		WithOrganization(*org).
+		Build()
+
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Namespace != org.GetNamespace() {
+		t.Errorf("Namespace not as expected. Expected: %s, Actual: %s", org.GetNamespace(), app.Namespace)
 	}
 }
 

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -34,8 +34,8 @@ const (
 func NewClusterApp(clusterName string, provider Provider) *Cluster {
 	org := organization.NewRandomOrg()
 
-	clusterApp := New(clusterName, fmt.Sprintf("cluster-%s", provider)).WithNamespace(org.GetNamespace())
-	defaultAppsApp := New(fmt.Sprintf("%s-default-apps", clusterName), fmt.Sprintf("default-apps-%s", provider)).WithNamespace(org.GetNamespace())
+	clusterApp := New(clusterName, fmt.Sprintf("cluster-%s", provider)).WithOrganization(*org)
+	defaultAppsApp := New(fmt.Sprintf("%s-default-apps", clusterName), fmt.Sprintf("default-apps-%s", provider)).WithOrganization(*org)
 
 	return &Cluster{
 		Name:           clusterName,
@@ -44,22 +44,6 @@ func NewClusterApp(clusterName string, provider Provider) *Cluster {
 		DefaultAppsApp: defaultAppsApp,
 		Organization:   org,
 	}
-}
-
-// WithOrg sets the Organization for the cluster and updates the namespace to that specified by the provided Org
-func (c *Cluster) WithOrg(org *organization.Org) *Cluster {
-	c.Organization = org
-	return c.WithNamespace(org.GetNamespace())
-}
-
-// WithNamespace sets the Namespace value
-//
-// Note: this may be overwritten if [Cluster.WithOrg] is used after.
-func (c *Cluster) WithNamespace(namespace string) *Cluster {
-	c.Namespace = namespace
-	c.ClusterApp = c.ClusterApp.WithNamespace(namespace)
-	c.DefaultAppsApp = c.DefaultAppsApp.WithNamespace(namespace)
-	return c
 }
 
 // WithAppVersions sets the Version values

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -12,7 +12,6 @@ import (
 // Cluster is a wrapper around Cluster and Default-apps Apps that makes creating them together easier
 type Cluster struct {
 	Name           string
-	Namespace      string
 	ClusterApp     *Application
 	DefaultAppsApp *Application
 	Organization   *organization.Org
@@ -39,11 +38,16 @@ func NewClusterApp(clusterName string, provider Provider) *Cluster {
 
 	return &Cluster{
 		Name:           clusterName,
-		Namespace:      org.GetNamespace(),
 		ClusterApp:     clusterApp,
 		DefaultAppsApp: defaultAppsApp,
 		Organization:   org,
 	}
+}
+
+// WithOrg sets the Organization for the cluster and updates the namespace to that specified by the provided Org
+func (c *Cluster) WithOrg(org *organization.Org) *Cluster {
+	c.Organization = org
+	return c
 }
 
 // WithAppVersions sets the Version values
@@ -86,7 +90,7 @@ func (c *Cluster) WithAppValuesFile(clusterValuesFile string, defaultAppsValuesF
 
 func (c *Cluster) setDefaultTemplateValues(templateValues *TemplateValues) {
 	templateValues.ClusterName = c.Name
-	templateValues.Namespace = c.Namespace
+	templateValues.Namespace = c.Organization.GetNamespace()
 	templateValues.Organization = c.Organization.Name
 }
 
@@ -134,7 +138,7 @@ func (c *Cluster) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, *applica
 
 	// Add missing config
 	defaultAppsApplication.Spec.Config.ConfigMap.Name = fmt.Sprintf("%s-cluster-values", c.Name)
-	defaultAppsApplication.Spec.Config.ConfigMap.Namespace = c.Namespace
+	defaultAppsApplication.Spec.Config.ConfigMap.Namespace = c.Organization.GetNamespace()
 
 	return clusterApplication, clusterCM, defaultAppsApplication, defaultAppsCM, nil
 }

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -144,3 +144,8 @@ func (c *Cluster) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, *applica
 
 	return clusterApplication, clusterCM, defaultAppsApplication, defaultAppsCM, nil
 }
+
+// GetNamespace returns the cluster organization namespace.
+func (c *Cluster) GetNamespace() string {
+	return c.Organization.GetNamespace()
+}

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -47,6 +47,8 @@ func NewClusterApp(clusterName string, provider Provider) *Cluster {
 // WithOrg sets the Organization for the cluster and updates the namespace to that specified by the provided Org
 func (c *Cluster) WithOrg(org *organization.Org) *Cluster {
 	c.Organization = org
+	c.ClusterApp = c.ClusterApp.WithOrganization(*org)
+	c.DefaultAppsApp = c.DefaultAppsApp.WithOrganization(*org)
 	return c
 }
 
@@ -138,7 +140,7 @@ func (c *Cluster) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, *applica
 
 	// Add missing config
 	defaultAppsApplication.Spec.Config.ConfigMap.Name = fmt.Sprintf("%s-cluster-values", c.Name)
-	defaultAppsApplication.Spec.Config.ConfigMap.Namespace = c.Organization.GetNamespace()
+	defaultAppsApplication.Spec.Config.ConfigMap.Namespace = c.DefaultAppsApp.Organization.GetNamespace()
 
 	return clusterApplication, clusterCM, defaultAppsApplication, defaultAppsCM, nil
 }

--- a/pkg/application/cluster_app_test.go
+++ b/pkg/application/cluster_app_test.go
@@ -12,11 +12,11 @@ func TestClusterAppDefaults(t *testing.T) {
 		t.Errorf("Cluster name not as expected. Expected %s, Actual: %s", clusterName, cluster.Name)
 	}
 
-	if cluster.ClusterApp.Organization.GetNamespace() != cluster.Organization.GetNamespace() {
-		t.Errorf("ClusterApp namespace not as expected. Expected %s, Actual: %s", cluster.Organization.GetNamespace(), cluster.ClusterApp.Organization.GetNamespace())
+	if cluster.ClusterApp.Organization.GetNamespace() != cluster.GetNamespace() {
+		t.Errorf("ClusterApp namespace not as expected. Expected %s, Actual: %s", cluster.GetNamespace(), cluster.ClusterApp.Organization.GetNamespace())
 	}
 
-	if cluster.DefaultAppsApp.Organization.GetNamespace() != cluster.Organization.GetNamespace() {
-		t.Errorf("DefaultAppsApp namespace not as expected. Expected %s, Actual: %s", cluster.Organization.GetNamespace(), cluster.DefaultAppsApp.Organization.GetNamespace())
+	if cluster.DefaultAppsApp.Organization.GetNamespace() != cluster.GetNamespace() {
+		t.Errorf("DefaultAppsApp namespace not as expected. Expected %s, Actual: %s", cluster.GetNamespace(), cluster.DefaultAppsApp.Organization.GetNamespace())
 	}
 }

--- a/pkg/application/cluster_app_test.go
+++ b/pkg/application/cluster_app_test.go
@@ -12,15 +12,11 @@ func TestClusterAppDefaults(t *testing.T) {
 		t.Errorf("Cluster name not as expected. Expected %s, Actual: %s", clusterName, cluster.Name)
 	}
 
-	if cluster.ClusterApp.Organization.GetNamespace() != cluster.Namespace {
-		t.Errorf("ClusterApp namespace not as expected. Expected %s, Actual: %s", cluster.Namespace, cluster.ClusterApp.Organization.GetNamespace())
+	if cluster.ClusterApp.Organization.GetNamespace() != cluster.Organization.GetNamespace() {
+		t.Errorf("ClusterApp namespace not as expected. Expected %s, Actual: %s", cluster.Organization.GetNamespace(), cluster.ClusterApp.Organization.GetNamespace())
 	}
 
-	if cluster.DefaultAppsApp.Organization.GetNamespace() != cluster.Namespace {
-		t.Errorf("DefaultAppsApp namespace not as expected. Expected %s, Actual: %s", cluster.Namespace, cluster.DefaultAppsApp.Organization.GetNamespace())
-	}
-
-	if cluster.Namespace != cluster.Organization.GetNamespace() {
-		t.Errorf("Cluster namespace doesn't match Org namespace. Expected: %s, Actual: %s", cluster.Organization.GetNamespace(), cluster.Namespace)
+	if cluster.DefaultAppsApp.Organization.GetNamespace() != cluster.Organization.GetNamespace() {
+		t.Errorf("DefaultAppsApp namespace not as expected. Expected %s, Actual: %s", cluster.Organization.GetNamespace(), cluster.DefaultAppsApp.Organization.GetNamespace())
 	}
 }

--- a/pkg/application/cluster_app_test.go
+++ b/pkg/application/cluster_app_test.go
@@ -12,12 +12,12 @@ func TestClusterAppDefaults(t *testing.T) {
 		t.Errorf("Cluster name not as expected. Expected %s, Actual: %s", clusterName, cluster.Name)
 	}
 
-	if cluster.ClusterApp.Namespace != cluster.Namespace {
-		t.Errorf("ClusterApp namespace not as expected. Expected %s, Actual: %s", cluster.Namespace, cluster.ClusterApp.Namespace)
+	if cluster.ClusterApp.Organization.GetNamespace() != cluster.Namespace {
+		t.Errorf("ClusterApp namespace not as expected. Expected %s, Actual: %s", cluster.Namespace, cluster.ClusterApp.Organization.GetNamespace())
 	}
 
-	if cluster.DefaultAppsApp.Namespace != cluster.Namespace {
-		t.Errorf("DefaultAppsApp namespace not as expected. Expected %s, Actual: %s", cluster.Namespace, cluster.DefaultAppsApp.Namespace)
+	if cluster.DefaultAppsApp.Organization.GetNamespace() != cluster.Namespace {
+		t.Errorf("DefaultAppsApp namespace not as expected. Expected %s, Actual: %s", cluster.Namespace, cluster.DefaultAppsApp.Organization.GetNamespace())
 	}
 
 	if cluster.Namespace != cluster.Organization.GetNamespace() {

--- a/pkg/application/doc.go
+++ b/pkg/application/doc.go
@@ -1,4 +1,4 @@
-// package application provides wrapper types around the concept of an App and its associated values ConfigMap.
+// Package application provides wrapper types around the concept of an App and its associated values ConfigMap.
 //
 // A standard [Application] type is available as well as a [Cluster] helper type that encapsulates both the
 // cluster app and the associated default-apps and their values ConfigMaps. The [Cluster] type also handles
@@ -7,7 +7,7 @@
 // # Creating an App
 //
 //	app := application.New("test-installation", "external-dns").
-//		WithNamespace("default").
+//		WithOrganization("giantswarm").
 //		WithVersion("").
 //		MustWithValuesFile("./test_data/externaldns_values.yaml", &application.ValuesTemplateVars{})
 //

--- a/pkg/organization/organization.go
+++ b/pkg/organization/organization.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"fmt"
+	"strings"
 
 	templateorg "github.com/giantswarm/kubectl-gs/v2/pkg/template/organization"
 	orgv1alpha1 "github.com/giantswarm/organization-operator/api/v1alpha1"
@@ -37,6 +38,14 @@ func New(name string) *Org {
 	return &Org{
 		Name:      name,
 		namespace: fmt.Sprintf("org-%s", name),
+	}
+}
+
+// NewFromNamespace returns a new Org, taking the name from the passed namespace.
+func NewFromNamespace(namespace string) *Org {
+	return &Org{
+		Name:      strings.TrimPrefix(namespace, "org-"),
+		namespace: namespace,
 	}
 }
 


### PR DESCRIPTION
We found out that `kubectl-gs` logic won't use the `Namespace` field when setting `InCluster` to false. In that case, it uses the `Organization`,  so we need to be able to set it.