### PR TITLE
Update ClusterValues to handle unmarshalling both NodePools types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly handle both types of NodePools in our values yaml
+
 ## [0.3.0] - 2023-08-24
 
 ### Changed

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -1,11 +1,40 @@
 package application
 
+import "encoding/json"
+
 // ClusterValues holds common values for cluster-<provider> charts. These are
 // the provider independent values and are present for all the charts
+//
+// The `NodePools` property supports both the []Nodepool and map[string]NodePool
+// types in the yaml values files and will handle both correctly as a map.
 type ClusterValues struct {
-	BaseDomain   string              `yaml:"baseDomain"`
-	ControlPlane ControlPlane        `yaml:"controlPlane"`
-	NodePools    map[string]NodePool `yaml:"nodePools"`
+	BaseDomain   string       `yaml:"baseDomain"`
+	ControlPlane ControlPlane `yaml:"controlPlane"`
+	NodePools    NodePools    `yaml:"nodePools"`
+}
+
+// NodePools is a special type containing a custom unmarshaller that can handle
+// both []Nodepool and map[string]NodePool types in the yaml values.
+type NodePools map[string]NodePool
+
+// UnmarshalJSON is a custom unmarshaller than handles both types of NodePools that our
+// apps use: []Nodepool and map[string]NodePool. Both will be unmarshalled into a map[string]NodePool
+func (np *NodePools) UnmarshalJSON(b []byte) error {
+	if b[0] != '[' {
+		// We're not dealing with an array so we can assume its the map we expect
+		return json.Unmarshal(b, (*map[string]NodePool)(np))
+	}
+	// We need to unmarshal as an array and then convert to the map we need
+	var nps []NodePool
+	if err := json.Unmarshal(b, &nps); err != nil {
+		return err
+	}
+	npMap := map[string]NodePool{}
+	for _, n := range nps {
+		npMap[*n.Name] = n
+	}
+	*np = NodePools(npMap)
+	return nil
 }
 
 type ControlPlane struct {
@@ -13,9 +42,10 @@ type ControlPlane struct {
 }
 
 type NodePool struct {
-	Replicas int `yaml:"replicas"`
-	MaxSize  int `yaml:"maxSize"`
-	MinSize  int `yaml:"minSize"`
+	Replicas int     `yaml:"replicas"`
+	MaxSize  int     `yaml:"maxSize"`
+	MinSize  int     `yaml:"minSize"`
+	Name     *string `yaml:"name"`
 }
 
 // DefaultAppsValues holds common values for default-apps-<provider> charts. These are

--- a/pkg/application/types_test.go
+++ b/pkg/application/types_test.go
@@ -1,0 +1,134 @@
+package application
+
+import (
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+func TestClusterValuesNodePool(t *testing.T) {
+	type errorTestCases struct {
+		description string
+		input       string
+		expectError bool
+		expected    ClusterValues
+	}
+
+	for _, scenario := range []errorTestCases{
+		{
+			description: "empty values",
+			input:       ``,
+			expectError: false,
+			expected:    ClusterValues{},
+		},
+		{
+			description: "single map",
+			input: `nodePools:
+  pool1:
+    minSize: 1
+    maxSize: 1
+    replicas: 1`,
+			expectError: false,
+			expected: ClusterValues{
+				NodePools: NodePools{
+					"pool1": NodePool{
+						Replicas: 1,
+						MinSize:  1,
+						MaxSize:  1,
+					},
+				},
+			},
+		},
+		{
+			description: "multiple map",
+			input: `nodePools:
+  pool1:
+    minSize: 1
+    maxSize: 1
+    replicas: 1
+  pool2:
+    minSize: 2
+    maxSize: 2
+    replicas: 2`,
+			expectError: false,
+			expected: ClusterValues{
+				NodePools: NodePools{
+					"pool1": NodePool{
+						Replicas: 1,
+						MinSize:  1,
+						MaxSize:  1,
+					},
+					"pool2": NodePool{
+						Replicas: 2,
+						MinSize:  2,
+						MaxSize:  2,
+					},
+				},
+			},
+		},
+		{
+			description: "single array",
+			input: `nodePools:
+- name: pool1
+  minSize: 1
+  maxSize: 1
+  replicas: 1`,
+			expectError: false,
+			expected: ClusterValues{
+				NodePools: NodePools{
+					"pool1": NodePool{
+						Replicas: 1,
+						MinSize:  1,
+						MaxSize:  1,
+					},
+				},
+			},
+		},
+		{
+			description: "multiple array",
+			input: `nodePools:
+- name: pool1
+  minSize: 1
+  maxSize: 1
+  replicas: 1
+- name: pool2
+  minSize: 2
+  maxSize: 2
+  replicas: 2`,
+			expectError: false,
+			expected: ClusterValues{
+				NodePools: NodePools{
+					"pool1": NodePool{
+						Replicas: 1,
+						MinSize:  1,
+						MaxSize:  1,
+					},
+					"pool2": NodePool{
+						Replicas: 2,
+						MinSize:  2,
+						MaxSize:  2,
+					},
+				},
+			},
+		},
+		{
+			description: "not a node pool type",
+			input:       `nodePools: 123`,
+			expectError: true,
+			expected:    ClusterValues{},
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			actual := &ClusterValues{}
+			err := yaml.Unmarshal([]byte(scenario.input), actual)
+			if err != nil && !scenario.expectError {
+				t.Fatalf("Didn't expect an error but there was one - %s", err)
+			} else if err == nil && scenario.expectError {
+				t.Fatalf("Expected an error but there wasn't one")
+			}
+			if len(actual.NodePools) != len(scenario.expected.NodePools) {
+				t.Errorf("Result didn't have expected number of node pools. Expected %d, Actual %d", len(actual.NodePools), len(scenario.expected.NodePools))
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds a custom unmarshaller to the `NodePools` type to check if the raw json begins with a `[` or not and based on that decides to unmarshal it as an array (and build a map from it) or a map.