### PR TITLE
Check for '-app' suffix variation when getting latest releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Check for `-app` suffix variations when failing to lookup an apps releases
+
 ## [0.4.0] - 2023-09-12
 
 ### Added

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -204,3 +204,35 @@ func TestWithVersion_Override(t *testing.T) {
 		t.Errorf("Was not expecting version to be overridden. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
 	}
 }
+
+func TestWithVersion_SuffixVariations(t *testing.T) {
+	// Test latest version with matching repo name
+	app, _, err := New("installName", "cluster-aws").WithVersion("latest").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version == "" {
+		t.Errorf("Was expecting a version from GitHub. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
+	}
+
+	// Test latest version with extra `-app` suffix not found on repo
+	app, _, err = New("installName", "cluster-aws-app").WithVersion("latest").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version == "" {
+		t.Errorf("Was expecting a version from GitHub. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
+	}
+
+	// Test latest version with missing `-app` suffix that is found on repo
+	app, _, err = New("installName", "ingress-nginx").WithVersion("latest").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version == "" {
+		t.Errorf("Was expecting a version from GitHub. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
+	}
+}

--- a/pkg/application/github.go
+++ b/pkg/application/github.go
@@ -1,0 +1,60 @@
+package application
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"golang.org/x/oauth2"
+
+	"github.com/google/go-github/v55/github"
+
+	"github.com/giantswarm/clustertest/pkg/utils"
+)
+
+// newGitHubClient returns a new initialized GitHub client using the GitHub token specified in the environment
+func newGitHubClient(ctx context.Context) *github.Client {
+	var ghHTTPClient *http.Client
+	githubToken := utils.GetGitHubToken()
+	if githubToken != "" {
+		ghHTTPClient = oauth2.NewClient(ctx, oauth2.StaticTokenSource(
+			&oauth2.Token{AccessToken: githubToken},
+		))
+	}
+
+	return github.NewClient(ghHTTPClient)
+}
+
+// getLatestReleaseVersion returns the latest version (tag) name for a given repos release.
+//
+// This function attempts to check for repos both with and without the `-app` suffix of the provided `applicationName`.
+// The provided `applicationName` is used as preference when looking up releases but if fails will fallback to the
+// suffix variation.
+func getLatestReleaseVersion(applicationName string) (string, error) {
+	ctx := context.Background()
+	gh := newGitHubClient(ctx)
+
+	appNameVariations := []string{applicationName}
+	if strings.HasSuffix(applicationName, "-app") {
+		appNameVariations = append(appNameVariations, strings.TrimSuffix(applicationName, "-app"))
+	} else {
+		appNameVariations = append(appNameVariations, applicationName+"-app")
+	}
+
+	var releases []*github.RepositoryRelease
+	var err error
+	for _, appName := range appNameVariations {
+		releases, _, err = gh.Repositories.ListReleases(ctx, "giantswarm", appName, &github.ListOptions{PerPage: 1})
+		if err == nil {
+			// We've found a matching repo so no need to keep checking
+			break
+		}
+	}
+
+	if len(releases) == 0 {
+		return "", fmt.Errorf("unable to get latest release of %s", applicationName)
+	}
+
+	return *releases[0].TagName, nil
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28066

When an App name doesn't match the name used for the repo because of an `-app` suffix we'll attempt to find the alternative if we couldn't find the releases with the provided name.