### PR TITLE
Support overriding the App repo name

### DIFF
--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -33,6 +33,7 @@ type Application struct {
 	Organization         organization.Org
 	UserConfigSecretName string
 	ExtraConfigs         []applicationv1alpha1.AppExtraConfig
+	RepoName             string
 
 	AppLabels       map[string]string
 	ConfigMapLabels map[string]string
@@ -43,6 +44,7 @@ func New(installName string, appName string) *Application {
 	return &Application{
 		InstallName:  installName,
 		AppName:      appName,
+		RepoName:     appName,
 		Version:      "",
 		Catalog:      "cluster",
 		Values:       "\n",
@@ -161,6 +163,15 @@ func (a *Application) WithExtraConfigs(extraConfigs []applicationv1alpha1.AppExt
 	return a
 }
 
+// WithRepoName sets the GitHub repository name associated with this application
+//
+// This is usually not needed and currently only required if using the `latest` version
+// and the repo name is vastly different to the App name (not just the `-app` suffix)
+func (a *Application) WithRepoName(repoName string) *Application {
+	a.RepoName = repoName
+	return a
+}
+
 // Build generates the App and ConfigMap resources
 func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, error) {
 	switch a.Version {
@@ -177,7 +188,7 @@ func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, erro
 		}
 		fallthrough
 	case "latest":
-		latestVersion, err := getLatestReleaseVersion(a.AppName)
+		latestVersion, err := getLatestReleaseVersion(a.RepoName)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -236,3 +236,27 @@ func TestWithVersion_SuffixVariations(t *testing.T) {
 		t.Errorf("Was expecting a version from GitHub. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
 	}
 }
+
+func TestWithRepoName(t *testing.T) {
+	// Overriding the repo name with a valid repo should correctly be able to fetch the latest version from the releases of that repo
+	app, _, err := New("installName", "my-custom-cluster-aws-app-name").
+		WithRepoName("cluster-aws").
+		WithVersion("latest").
+		Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Version == "" {
+		t.Errorf("Was expecting a version from GitHub. Expected: (latest from GitHub), Actual: %s", app.Spec.Version)
+	}
+
+	// Overriding the repo with a non-existent name should return an error when attempting to get the latest version
+	_, _, err = New("installName", "cluster-aws").
+		WithRepoName("not-a-real-repo-name").
+		WithVersion("latest").
+		Build()
+	if err == nil {
+		t.Fatalf("Was expecting an error: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/giantswarm/issues/28066

Generally this shouldn't be needed but if we happen to have an App that has a very different repo name this will allow setting it manually to ensure getting the latest version still works as expected.