### PR TITLE
Improve Application to allow installing into workload clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `WithNamespace` and `WithClusterName` to Application to support installing apps into workload clusters
+- Added `WithInstallNamespace` and `WithClusterName` to Application to support installing apps into workload clusters
 - Added error handler to ensure a `ClusterName` is provided with an Application if `InCluster` is set to `false`
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `WithNamespace` and `WithClusterName` to Application to support installing apps into workload clusters
+- Added error handler to ensure a `ClusterName` is provided with an Application if `InCluster` is set to `false`
+
+### Fixed
+
+- Correctly set the `app.Spec.KubeConfig.Context.Name` to the value used by CAPI
+
 ## [0.5.0] - 2023-09-14
 
 ### Added

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -183,7 +183,7 @@ func (a *Application) WithClusterName(clusterName string) *Application {
 	return a
 }
 
-// WithInstallNamespace sets the namespace that the App will eventually be installed into.
+// WithInstallNamespace sets the namespace used by helm to install the chart
 // This can be different to the namespace the App CR is in.
 func (a *Application) WithInstallNamespace(namespace string) *Application {
 	a.InstallNamespace = namespace

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -278,7 +278,7 @@ func TestBuild_WCAppInstall(t *testing.T) {
 		WithVersion(version).
 		WithInCluster(false).
 		WithClusterName(clusterName).
-		WithNamespace(namespace)
+		WithInstallNamespace(namespace)
 
 	app, _, err := appBuilder.Build()
 	if err != nil {
@@ -307,6 +307,7 @@ func TestBuild_WCAppInstall(t *testing.T) {
 	if app.Spec.Namespace != namespace {
 		t.Errorf("Was expecting the App specs namespace to be '%s', but was '%s'", namespace, app.Spec.Namespace)
 	}
+
 	if app.ObjectMeta.Namespace != org.GetNamespace() {
 		t.Errorf("Was expecting the App CR namespace to be '%s', but was '%s'", org.GetNamespace(), app.ObjectMeta.Namespace)
 	}


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/giantswarm/issues/28067

Adds more config used when installing apps into workload clusters rather than the management cluster. This exposes setting the `Cluster` property that's used to populate labels and allows setting a `Namespace` that the app contents will be installed into.

This PR also introduces a fix for the kubeconfig context name generated by kubectl-gs to actually be the one used by CAPI.