### PR TITLE
Fixes for broken App deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added a `GetInstallNamespace` helper function for Application
+- Added `DeleteApp` helper function to remove an App CR and its ConfigMap from the cluster
 
 ## [0.6.0] - 2023-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Correctly set the namespace on Applications
 
+### Added
+
+- Added a `GetInstallNamespace` helper function for Application
+
 ## [0.6.0] - 2023-09-14
 
 ### Added

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -311,5 +311,91 @@ func TestBuild_WCAppInstall(t *testing.T) {
 	if app.ObjectMeta.Namespace != org.GetNamespace() {
 		t.Errorf("Was expecting the App CR namespace to be '%s', but was '%s'", org.GetNamespace(), app.ObjectMeta.Namespace)
 	}
+}
 
+func TestGetNamespace(t *testing.T) {
+	org := organization.New("t-123456")
+	baseApp := func() *Application {
+		return New("in-cluster-org-namespace", "example-app").
+			WithVersion("1.0.0").
+			WithOrganization(*org)
+	}
+
+	type errorTestCases struct {
+		description       string
+		app               *Application
+		expectedNamespace string
+	}
+
+	for _, scenario := range []errorTestCases{
+		{
+			description:       "in cluster with org namespace",
+			app:               baseApp().WithInCluster(true),
+			expectedNamespace: org.GetNamespace(),
+		},
+		{
+			description:       "in cluster with custom install namespace",
+			app:               baseApp().WithInCluster(true).WithInstallNamespace("my-namespace"),
+			expectedNamespace: "my-namespace",
+		},
+		{
+			description:       "out cluster with custom install namespace",
+			app:               baseApp().WithInCluster(false).WithClusterName("my-cluster").WithInstallNamespace("my-namespace"),
+			expectedNamespace: org.GetNamespace(),
+		},
+		{
+			description:       "out cluster with org namespace",
+			app:               baseApp().WithInCluster(false).WithClusterName("my-cluster"),
+			expectedNamespace: org.GetNamespace(),
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			if scenario.app.GetNamespace() != scenario.expectedNamespace {
+				t.Errorf("Expected the app namespace to be '%s' but instead got '%s'", scenario.expectedNamespace, scenario.app.GetNamespace())
+			}
+		})
+	}
+}
+func TestGetInstallNamespace(t *testing.T) {
+	org := organization.New("t-123456")
+	baseApp := func() *Application {
+		return New("in-cluster-org-namespace", "example-app").
+			WithVersion("1.0.0").
+			WithOrganization(*org)
+	}
+
+	type errorTestCases struct {
+		description       string
+		app               *Application
+		expectedNamespace string
+	}
+
+	for _, scenario := range []errorTestCases{
+		{
+			description:       "in cluster with org namespace",
+			app:               baseApp().WithInCluster(true),
+			expectedNamespace: org.GetNamespace(),
+		},
+		{
+			description:       "in cluster with custom install namespace",
+			app:               baseApp().WithInCluster(true).WithInstallNamespace("my-namespace"),
+			expectedNamespace: "my-namespace",
+		},
+		{
+			description:       "out cluster with custom install namespace",
+			app:               baseApp().WithInCluster(false).WithClusterName("my-cluster").WithInstallNamespace("my-namespace"),
+			expectedNamespace: "my-namespace",
+		},
+		{
+			description:       "out cluster with org namespace",
+			app:               baseApp().WithInCluster(false).WithClusterName("my-cluster"),
+			expectedNamespace: org.GetNamespace(),
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			if scenario.app.GetInstallNamespace() != scenario.expectedNamespace {
+				t.Errorf("Expected the app namespace to be '%s' but instead got '%s'", scenario.expectedNamespace, scenario.app.GetInstallNamespace())
+			}
+		})
+	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -265,3 +265,20 @@ func (c *Client) DeployAppManifests(ctx context.Context, appCR *applicationv1alp
 
 	return nil
 }
+
+// DeleteApp removes an App CR and its ConfigMap from the cluster
+func (c *Client) DeleteApp(ctx context.Context, app application.Application) error {
+	appCR, configMap, err := app.Build()
+	if err != nil {
+		return err
+	}
+
+	if err := c.Delete(ctx, appCR); err != nil {
+		return fmt.Errorf("failed to delete app CR: %v", err)
+	}
+	if err := c.Delete(ctx, configMap); err != nil {
+		return fmt.Errorf("failed to delete app CR: %v", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION

### Fixed

- Correctly set the namespace on Applications

### Added

- Added a `GetInstallNamespace` helper function for Application
- Added `DeleteApp` helper function to remove an App CR and its ConfigMap from the cluster
