### PR TITLE
Use custom DNS for k8s api in kubeconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Modify kubeconfig of workload clusters to use DNS hostname of server also when an AWS ELB dns is found.
+
 ## [0.7.0] - 2023-09-15
 
 ## [0.6.1] - 2023-09-15

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/url"
 	"reflect"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -149,8 +150,8 @@ func (c *Client) GetClusterKubeConfig(ctx context.Context, clusterName string, c
 			return "", err
 		}
 
-		// Check if the server uses an IP address for the hostname, if so we need to replace it with the DNS hostname
-		if net.ParseIP(u.Hostname()) != nil {
+		// Check if the server uses an IP address for the hostname, or it's the ELB dns, if so we need to replace it with the custom DNS hostname we create
+		if net.ParseIP(u.Hostname()) != nil || strings.Contains(u.Hostname(), "elb.amazonaws.com") {
 			// We need to build up the hostname from the base domain and cluster name
 			var clusterValuesCM corev1.ConfigMap
 			err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("%s-cluster-values", clusterName), Namespace: clusterNamespace}, &clusterValuesCM)


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2351

We also need this for CAPA clusters if we want to use our VPN to access them.