### PR TITLE
Reduce DefaultTimeout to 30 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduce the `DefaultTimeout` value from 60 min to 30 min
+
 ## [0.8.0] - 2023-09-27
 
 ### Changed

--- a/pkg/wait/wait.go
+++ b/pkg/wait/wait.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	// DefaultTimeout is the default max time to wait before returning an error if a timeout is not provided
-	DefaultTimeout = 1 * time.Hour
+	DefaultTimeout = 30 * time.Minute
 	// DefaultInterval is the polling interval to use if an interval is not provided
 	DefaultInterval = 10 * time.Second
 )


### PR DESCRIPTION
This PR reduces the DefaultTimeout by half to discourage the use of it in place of more relevant values. Based on data collected form the past week worth of runs on Tekton, no individual step took longer than 30 minutes so this should be safe to drop. 

I'll be doing a change to `cluster-test-suites` shortly after this is released to update the dependancy and replace the current references to `DefaultTimeout` with more appropriate timeouts for each task.

Towards: https://github.com/giantswarm/giantswarm/issues/28028