### PR TITLE
Switch to using ServiceAccount auth for WC kube client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Instead of relying on the CAPI-generated kubeconfig we now create a specific ServiceAccount in the workload cluster and authenticate as that for the test suites.
+
 ## [0.11.0] - 2023-10-27
 
 ### Changed

--- a/pkg/testuser/doc.go
+++ b/pkg/testuser/doc.go
@@ -1,0 +1,10 @@
+// package testuser handles creating a user within the cluster that can be used for authentication by the tests.
+//
+// A ServiceAccount is created and associated with the `cluster-admin` ClusterRole. A Secret is created and linked
+// to the ServiceAccount to ensure an API token is generated for the ServiceAccount. The details from this Secret
+// is then used to template a new KubeConfig and build a new Kubernetes client that is then returned for use by the
+// test suite from then onwards.
+//
+// This approach is specifically required for clusters that use an `exec` auth method (such as EKS) that isn't
+// possible within the test environment but should be used for all providers / clusters for consistency.
+package testuser

--- a/pkg/testuser/resources.go
+++ b/pkg/testuser/resources.go
@@ -1,0 +1,50 @@
+package testuser
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	accountName = "e2e-test-account"
+	namespace   = metav1.NamespaceDefault
+)
+
+var serviceAccount = corev1.ServiceAccount{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      accountName,
+		Namespace: namespace,
+	},
+}
+
+var secret = corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      fmt.Sprintf("%s-secret", accountName),
+		Namespace: namespace,
+		Annotations: map[string]string{
+			"kubernetes.io/service-account.name": accountName,
+		},
+	},
+	Type: corev1.SecretTypeServiceAccountToken,
+}
+
+var clusterRoleBinding = rbacv1.ClusterRoleBinding{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: accountName,
+	},
+	Subjects: []rbacv1.Subject{
+		{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      accountName,
+			Namespace: namespace,
+		},
+	},
+	RoleRef: rbacv1.RoleRef{
+		APIGroup: "rbac.authorization.k8s.io",
+		Kind:     "ClusterRole",
+		Name:     "cluster-admin",
+	},
+}

--- a/pkg/testuser/template.go
+++ b/pkg/testuser/template.go
@@ -1,0 +1,28 @@
+package testuser
+
+type templateVars struct {
+	CA          string
+	Endpoint    string
+	AccountName string
+	Token       string
+}
+
+var kubeConfigTemplate = `apiVersion: v1
+kind: Config
+clusters:
+  - name: e2e-wc
+    cluster:
+      certificate-authority-data: {{ .CA }}
+      server: {{ .Endpoint }}
+contexts:
+  - name: {{ .AccountName }}@e2e-wc
+    context:
+      cluster: e2e-wc
+      namespace: default
+      user: {{ .AccountName }}
+users:
+  - name: {{ .AccountName }}
+    user:
+      token: {{ .Token }}
+current-context: {{ .AccountName }}@e2e-wc
+`

--- a/pkg/testuser/testuser.go
+++ b/pkg/testuser/testuser.go
@@ -1,0 +1,69 @@
+package testuser
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"html/template"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/wait"
+)
+
+// Create handles the creation of a ServiceAccount with cluster-admin permission within the cluster
+// and generated a new Kubernetes client that authenticates as that account.
+func Create(ctx context.Context, kubeClient *client.Client) (*client.Client, error) {
+	// ServiceAccount
+	if err := kubeClient.Create(ctx, &serviceAccount); err != nil {
+		return nil, err
+	}
+	// Secret
+	if err := kubeClient.Create(ctx, &secret); err != nil {
+		return nil, err
+	}
+	// ClusterRoleBinding
+	if err := kubeClient.Create(ctx, &clusterRoleBinding); err != nil {
+		return nil, err
+	}
+
+	var ca string
+	var token string
+
+	err := wait.For(
+		func() (bool, error) {
+			var populatedSecret corev1.Secret
+			err := kubeClient.Get(ctx, types.NamespacedName{Name: secret.ObjectMeta.Name, Namespace: secret.ObjectMeta.Namespace}, &populatedSecret)
+			if err != nil {
+				return false, err
+			}
+
+			ca = base64.StdEncoding.EncodeToString(populatedSecret.Data["ca.crt"])
+			token = string(populatedSecret.Data["token"])
+
+			return (ca != "" && token != ""), nil
+		},
+		wait.WithTimeout(5*time.Minute),
+		wait.WithInterval(1*time.Second),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	t := template.Must(template.New("kubeconfig").Parse(kubeConfigTemplate))
+	var buf bytes.Buffer
+	err = t.Execute(&buf, templateVars{
+		Endpoint:    kubeClient.GetAPIServerEndpoint(),
+		AccountName: accountName,
+		CA:          ca,
+		Token:       token,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return client.NewFromRawKubeconfig(buf.String())
+}

--- a/pkg/wait/conditions.go
+++ b/pkg/wait/conditions.go
@@ -52,21 +52,16 @@ func Consistent(action func() error, attempts int, pollInterval time.Duration) f
 }
 
 // IsClusterReadyCondition returns a WaitCondition to check when a cluster is considered ready and accessible
-func IsClusterReadyCondition(ctx context.Context, kubeClient *client.Client, clusterName string, namespace string, clientMap map[string]*client.Client) WaitCondition {
+func IsClusterReadyCondition(ctx context.Context, kubeClient *client.Client, clusterName string, namespace string) WaitCondition {
 	return func() (bool, error) {
 		logger.Log("Checking for valid Kubeconfig for cluster %s", clusterName)
 
-		kubeconfig, err := kubeClient.GetClusterKubeConfig(ctx, clusterName, namespace)
+		wcClient, err := client.NewFromSecret(ctx, kubeClient, clusterName, namespace)
 		if err != nil && cr.IgnoreNotFound(err) == nil {
 			// Kubeconfig not yet available
 			logger.Log("kubeconfig secret not yet available")
 			return false, nil
 		} else if err != nil {
-			return false, err
-		}
-
-		wcClient, err := client.NewFromRawKubeconfig(string(kubeconfig))
-		if err != nil {
 			return false, err
 		}
 
@@ -77,9 +72,6 @@ func IsClusterReadyCondition(ctx context.Context, kubeClient *client.Client, clu
 		}
 
 		logger.Log("Got valid kubeconfig!")
-
-		// Store client for later
-		clientMap[clusterName] = wcClient
 
 		return true, nil
 	}

--- a/pkg/wait/doc.go
+++ b/pkg/wait/doc.go
@@ -9,7 +9,7 @@
 // # Example using `For` with the `IsClusterReadyCondition` condition
 //
 //	err := wait.For(
-//		wait.IsClusterReadyCondition(ctx, f.MC(), clusterName, namespace, f.wcClients),
+//		wait.IsClusterReadyCondition(ctx, f.MC(), clusterName, namespace),
 //		wait.WithContext(ctx),
 //		wait.WithInterval(10*time.Second),
 //	)


### PR DESCRIPTION
To support EKS clusters, and any other that might require time-limited kubeconfig credentials, the test framework now creates a ServiceAccount with `cluster-admin` permissions in the workload cluster and creates a kubernetes client that authenticates as that account.

Along with the new `testuser` package that handles the creation of the resources and the generation of a new kube client we also introduce the following changes:

* `client.NewFromSecret` - helper function to get a kubeconfig from the known kubeconfig secret in an MC
* `client.GetAPIServerEndpoint` - Returns the API server URL, used when generating the new kubeconfig
* `wait.IsClusterReadyCondition` - no longer mutates the frameworks list of WC clients