### PR TITLE
Ensure the testuser ServiceAccount is only created once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure `testuser` isn't reapplied when `ApplyCluster` is called again (e.g. during the upgrade tests)
+
 ## [0.12.0] - 2023-11-02
 
 ### Changed


### PR DESCRIPTION
This change ensures that the testuser ServiceAccount is only created once in the Workload Cluster so that conflicts aren't faced when re-calling the `ApplyCluster` function, for example during the upgrade tests.