### PR TITLE
Null the resource versions 

### DIFF
--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -143,6 +143,12 @@ func (c *Cluster) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, *applica
 	defaultAppsApplication.Spec.Config.ConfigMap.Name = fmt.Sprintf("%s-cluster-values", c.Name)
 	defaultAppsApplication.Spec.Config.ConfigMap.Namespace = c.DefaultAppsApp.Organization.GetNamespace()
 
+	// null the .resourceVersions
+	clusterApplication.ResourceVersion = ""
+	clusterCM.ResourceVersion = ""
+	defaultAppsApplication.ResourceVersion = ""
+	defaultAppsCM.ResourceVersion = ""
+
 	return clusterApplication, clusterCM, defaultAppsApplication, defaultAppsCM, nil
 }
 


### PR DESCRIPTION
(useful when reusing existing resources in the builder)