### PR TITLE
Add custom unmarshaller to handle new and old schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a custom unmarshaller to `application.ClusterValues` to dynamically handle both the old and new values schemas while we migrate all cluster apps
+
 ### Changed
 
 - Bumped `golangci-lint` to latest version in CI

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -78,20 +78,25 @@ func (cv *ClusterValues) UnmarshalJSON(b []byte) error {
 		cv.BaseDomain = s.Global.Connectivity.BaseDomain
 		cv.ControlPlane = s.Global.ControlPlane
 		cv.NodePools = s.Global.NodePools
-	} else {
-		// We're dealing with the old schema
-		type Schema struct {
-			BaseDomain   string       `yaml:"baseDomain"`
-			ControlPlane ControlPlane `yaml:"controlPlane"`
-			NodePools    NodePools    `yaml:"nodePools"`
-		}
-		var s Schema
-		err := json.Unmarshal(b, &s)
-		if err != nil {
-			return err
-		}
+	}
+	// We're also checking the old schema
+	type Schema struct {
+		BaseDomain   string       `yaml:"baseDomain"`
+		ControlPlane ControlPlane `yaml:"controlPlane"`
+		NodePools    NodePools    `yaml:"nodePools"`
+	}
+	var s Schema
+	err := json.Unmarshal(b, &s)
+	if err != nil {
+		return err
+	}
+	if cv.BaseDomain == "" {
 		cv.BaseDomain = s.BaseDomain
+	}
+	if cv.ControlPlane.Replicas == 0 {
 		cv.ControlPlane = s.ControlPlane
+	}
+	if len(cv.NodePools) == 0 {
 		cv.NodePools = s.NodePools
 	}
 	return nil

--- a/pkg/application/types_test.go
+++ b/pkg/application/types_test.go
@@ -132,3 +132,161 @@ func TestClusterValuesNodePool(t *testing.T) {
 		})
 	}
 }
+
+func TestClusterValues(t *testing.T) {
+	type errorTestCases struct {
+		description string
+		input       string
+		expectError bool
+		expected    ClusterValues
+	}
+
+	for _, scenario := range []errorTestCases{
+		{
+			description: "empty values",
+			input:       ``,
+			expectError: false,
+			expected:    ClusterValues{},
+		},
+		{
+			description: "old schema",
+			input: `baseDomain: "foo.com"
+controlPlane:
+  replicas: 3`,
+			expectError: false,
+			expected: ClusterValues{
+				BaseDomain: "foo.com",
+				ControlPlane: ControlPlane{
+					Replicas: 3,
+				},
+			},
+		},
+		{
+			description: "old schema with nodepools map",
+			input: `baseDomain: "foo.com"
+controlPlane:
+  replicas: 3
+nodePools:
+  pool1:
+    minSize: 1
+    maxSize: 1
+    replicas: 1`,
+			expectError: false,
+			expected: ClusterValues{
+				BaseDomain: "foo.com",
+				ControlPlane: ControlPlane{
+					Replicas: 3,
+				},
+				NodePools: NodePools{
+					"pool1": NodePool{
+						MinSize:  1,
+						MaxSize:  1,
+						Replicas: 1,
+					},
+				},
+			},
+		},
+		{
+			description: "old schema with nodepools array",
+			input: `baseDomain: "foo.com"
+controlPlane:
+  replicas: 3
+nodePools:
+  - name: pool1
+    minSize: 1
+    maxSize: 1
+    replicas: 1`,
+			expectError: false,
+			expected: ClusterValues{
+				BaseDomain: "foo.com",
+				ControlPlane: ControlPlane{
+					Replicas: 3,
+				},
+				NodePools: NodePools{
+					"pool1": NodePool{
+						MinSize:  1,
+						MaxSize:  1,
+						Replicas: 1,
+					},
+				},
+			},
+		},
+		{
+			description: "new schema",
+			input: `global:
+  connectivity:
+    baseDomain: foo.com
+  controlPlane:
+    replicas: 3`,
+			expectError: false,
+			expected: ClusterValues{
+				BaseDomain: "foo.com",
+				ControlPlane: ControlPlane{
+					Replicas: 3,
+				},
+			},
+		},
+		{
+			description: "new schema with nodepool",
+			input: `global:
+  connectivity:
+    baseDomain: foo.com
+  controlPlane:
+    replicas: 3
+  nodePools:
+    pool1:
+      minSize: 1
+      maxSize: 1
+      replicas: 1`,
+			expectError: false,
+			expected: ClusterValues{
+				BaseDomain: "foo.com",
+				ControlPlane: ControlPlane{
+					Replicas: 3,
+				},
+				NodePools: NodePools{
+					"pool1": NodePool{
+						MinSize:  1,
+						MaxSize:  1,
+						Replicas: 1,
+					},
+				},
+			},
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			actual := &ClusterValues{}
+			err := yaml.Unmarshal([]byte(scenario.input), actual)
+			if err != nil && !scenario.expectError {
+				t.Fatalf("Didn't expect an error but there was one - %s", err)
+			} else if err == nil && scenario.expectError {
+				t.Fatalf("Expected an error but there wasn't one")
+			}
+			if actual.BaseDomain != scenario.expected.BaseDomain {
+				t.Errorf("Result didn't have expected base domain. Expected %d, Actual %d", len(actual.BaseDomain), len(scenario.expected.BaseDomain))
+			}
+			if actual.ControlPlane.Replicas != scenario.expected.ControlPlane.Replicas {
+				t.Errorf("Result didn't have expected control plane replicas. Expected %d, Actual %d", actual.ControlPlane.Replicas, scenario.expected.ControlPlane.Replicas)
+			}
+			if len(actual.NodePools) != len(scenario.expected.NodePools) {
+				t.Errorf("Result didn't have expected number of node pools. Expected %d, Actual %d", len(actual.NodePools), len(scenario.expected.NodePools))
+			}
+			for key, val := range scenario.expected.NodePools {
+				np, ok := actual.NodePools[key]
+				if !ok {
+					t.Errorf("Result didn't have expected node pool name. Expected %s", key)
+				} else {
+					if val.MaxSize != np.MaxSize {
+						t.Errorf("Result NodePool didn't have expected MaxSize. Expected %d, Actual %d", val.MaxSize, np.MaxSize)
+					}
+					if val.MinSize != np.MinSize {
+						t.Errorf("Result NodePool didn't have expected MinSize. Expected %d, Actual %d", val.MinSize, np.MinSize)
+					}
+					if val.Replicas != np.Replicas {
+						t.Errorf("Result NodePool didn't have expected Replicas. Expected %d, Actual %d", val.Replicas, np.Replicas)
+					}
+				}
+			}
+		})
+	}
+}

--- a/pkg/application/types_test.go
+++ b/pkg/application/types_test.go
@@ -253,6 +253,21 @@ nodePools:
 				},
 			},
 		},
+		{
+			description: "old schema but has a 'global' property",
+			input: `global:
+  metadata: {}
+baseDomain: "foo.com"
+controlPlane:
+  replicas: 3`,
+			expectError: false,
+			expected: ClusterValues{
+				BaseDomain: "foo.com",
+				ControlPlane: ControlPlane{
+					Replicas: 3,
+				},
+			},
+		},
 	} {
 		t.Run(scenario.description, func(t *testing.T) {
 			actual := &ClusterValues{}


### PR DESCRIPTION
The schema used by cluster apps are changing to move most of the values under a `global` property but it's going to take a while before all providers are updated to the new schema so we need a way of seamlessly handling both schemas without causing too much impact on the tests themselves. This change introduces a custom unmarshaller that checks which schema version we are working with and generate a `ClusterValues` object from their values.