### PR TITLE
Update WithVersion() logic to better set the test catalog

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -7,3 +7,7 @@ CVE-2022-29153
 
 # github.com/hashicorp/consul/sdk
 CVE-2022-29153
+
+# helm.sh/helm/v3
+CVE-2024-26147
+CVE-2024-25620

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `.WithVersion()` to better handle sha based versions and set the catalog to the currently set catalog with a `-test` suffix (instead of hardcoded to `cluster-test`)
+
 ## [0.14.0] - 2023-12-04
 
 ### Changed

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"regexp"
+	"strings"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
@@ -70,8 +71,8 @@ func (a *Application) WithVersion(version string) *Application {
 	a.Version = version
 
 	// Override the catalog if version contains a sha suffix
-	if isShaVersion.MatchString(version) {
-		a = a.WithCatalog("cluster-test")
+	if isShaVersion.MatchString(version) && !strings.HasSuffix(a.Catalog, "-test") {
+		a = a.WithCatalog(fmt.Sprintf("%s-test", a.Catalog))
 	}
 
 	return a

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -399,3 +399,85 @@ func TestGetInstallNamespace(t *testing.T) {
 		})
 	}
 }
+
+func TestWithVersion_Catalog(t *testing.T) {
+	defaultCatalog := "cluster"
+	defaultTestCatalog := "cluster-test"
+
+	// Test with default catalog (cluster) and default version
+	app, _, err := New("installName", "cluster-aws").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != defaultCatalog {
+		t.Errorf("Was expecting catalog to be default. Expected: %s, Actual: %s", defaultCatalog, app.Spec.Catalog)
+	}
+
+	// Test with default catalog (cluster) and custom version
+	app, _, err = New("installName", "cluster-aws").WithVersion("v1.2.3").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != defaultCatalog {
+		t.Errorf("Was expecting catalog to be default. Expected: %s, Actual: %s", defaultCatalog, app.Spec.Catalog)
+	}
+
+	// Test with default catalog (cluster) and sha-based version
+	app, _, err = New("installName", "cluster-aws").WithVersion("v1.2.3-68584a77efa719a74e0518163c1af38637927f73").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != defaultTestCatalog {
+		t.Errorf("Was expecting catalog to be default with test suffix. Expected: %s, Actual: %s", defaultTestCatalog, app.Spec.Catalog)
+	}
+
+	customCatalog := "giantswarm"
+	customTestCatalog := "giantswarm-test"
+
+	// Test with custom catalog and default version
+	app, _, err = New("installName", "cluster-aws").WithCatalog(customCatalog).Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != customCatalog {
+		t.Errorf("Was expecting catalog to match the provided. Expected: %s, Actual: %s", customCatalog, app.Spec.Catalog)
+	}
+
+	// Test with default catalog (cluster) and custom version
+	app, _, err = New("installName", "cluster-aws").WithCatalog(customCatalog).WithVersion("v1.2.3").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != customCatalog {
+		t.Errorf("Was expecting catalog to match the provided. Expected: %s, Actual: %s", customCatalog, app.Spec.Catalog)
+	}
+
+	// Test with default catalog (cluster) and sha-based version
+	app, _, err = New("installName", "cluster-aws").WithCatalog(customCatalog).WithVersion("v1.2.3-68584a77efa719a74e0518163c1af38637927f73").Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != customTestCatalog {
+		t.Errorf("Was expecting catalog to be the provided with the test suffix. Expected: %s, Actual: %s", customTestCatalog, app.Spec.Catalog)
+	}
+
+	// Ensure we can override the automatic catalog with subsequent call to .WithCatalog()
+
+	app, _, err = New("installName", "cluster-aws").
+		WithVersion("v1.2.3-68584a77efa719a74e0518163c1af38637927f73"). // Causes the catalog to become 'cluster-test'
+		WithCatalog("override").                                        // Overrides the catalog to 'override'
+		Build()
+	if err != nil {
+		t.Fatalf("Not expecting an error: %v", err)
+	}
+
+	if app.Spec.Catalog != "override" {
+		t.Errorf("Was expecting catalog to be the provided with the test suffix. Expected: %s, Actual: %s", "override", app.Spec.Catalog)
+	}
+}


### PR DESCRIPTION
If we have set a different catalog using `WithCatalog()` we should use that as the base for the test catalog if we're automatically overriding it based on a sha-based version number.

This only happens if the provided catalog doesn't already end in `-test`