### PR TITLE
Safely handle an empty values file

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -7,3 +7,7 @@ CVE-2022-29153
 
 # github.com/hashicorp/consul/sdk
 CVE-2022-29153
+
+# helm.sh/helm/v3
+CVE-2024-26147
+CVE-2024-25620

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Safely handle an empty values file being provided by replacing it with a single newline character
+
 ## [0.14.0] - 2023-12-04
 
 ### Changed

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -92,18 +92,7 @@ func (a *Application) WithCatalog(catalog string) *Application {
 //
 // The values supports templating using Go template strings and uses values provided in `config` to replace placeholders.
 func (a *Application) WithValues(values string, config *TemplateValues) (*Application, error) {
-	// We need to check that the values file actually has contents otherwise kubectl-gs fails to build the Application
-	fileBytes, err := os.ReadFile(values)
-	if err != nil {
-		return nil, err
-	}
-	if len(fileBytes) == 0 {
-		// Empty file so we'll set it to the default contents
-		a.Values = defaultValuesContents
-		return a, nil
-	}
-
-	values, err = parseTemplate(values, config)
+	values, err := parseTemplate(values, config)
 	if err != nil {
 		return nil, err
 	}
@@ -127,6 +116,17 @@ func (a *Application) MustWithValues(values string, config *TemplateValues) *App
 //
 // The file supports templating using Go template strings and uses values provided in `config` to replace placeholders.
 func (a *Application) WithValuesFile(filePath string, config *TemplateValues) (*Application, error) {
+	// We need to check that the values file actually has contents otherwise kubectl-gs fails to build the Application
+	fileBytes, err := os.ReadFile(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, err
+	}
+	if len(fileBytes) == 0 {
+		// Empty file so we'll set it to the default contents
+		a.Values = defaultValuesContents
+		return a, nil
+	}
+
 	values, err := parseTemplateFile(filePath, config)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
The kubectl-gs code that generates an Application CR (and ConfigMap) doesn't handle an empty values string and will instead panic. This adds a guard against it by ensuring that empty values values are replaced with a single newline character which is enough for the kubectl-gs code to work with.