### PR TITLE
Add WaitConditions to check for Cluster API status conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new WaitConditions to check for Cluster API status conditions.
+
 ## [0.17.0] - 2024-04-02
 
 ### Added

--- a/framework.go
+++ b/framework.go
@@ -359,6 +359,26 @@ func (f *Framework) GetAppAndValues(ctx context.Context, name, namespace string)
 	return app, values, nil
 }
 
+// GetKubeadmControlPlane returns the KubeadmControlPlane resource
+func (f *Framework) GetKubeadmControlPlane(ctx context.Context, clusterName string, clusterNamespace string) (*kubeadm.KubeadmControlPlane, error) {
+	controlPlane := &kubeadm.KubeadmControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: clusterNamespace,
+		},
+	}
+
+	err := f.MC().Get(ctx, cr.ObjectKeyFromObject(controlPlane), controlPlane)
+	if errors.IsNotFound(err) {
+		// If we don't find the `KubeadmControlPlane` we assume it's a managed control plane cluster and expect 0 control plane nodes
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	return controlPlane, nil
+}
+
 // GetExpectedControlPlaneReplicas returns the number of control plane node expected according to the clusters KubeadmControlPlane resource
 func (f *Framework) GetExpectedControlPlaneReplicas(ctx context.Context, clusterName string, clusterNamespace string) (int32, error) {
 	controlPlane := &kubeadm.KubeadmControlPlane{

--- a/framework.go
+++ b/framework.go
@@ -359,7 +359,8 @@ func (f *Framework) GetAppAndValues(ctx context.Context, name, namespace string)
 	return app, values, nil
 }
 
-// GetKubeadmControlPlane returns the KubeadmControlPlane resource
+// GetKubeadmControlPlane returns the KubeadmControlPlane resource. If we don't find the `KubeadmControlPlane` we assume
+// it's a managed control plane cluster and expect nil pointer to be returned without error.
 func (f *Framework) GetKubeadmControlPlane(ctx context.Context, clusterName string, clusterNamespace string) (*kubeadm.KubeadmControlPlane, error) {
 	controlPlane := &kubeadm.KubeadmControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
@@ -370,7 +371,8 @@ func (f *Framework) GetKubeadmControlPlane(ctx context.Context, clusterName stri
 
 	err := f.MC().Get(ctx, cr.ObjectKeyFromObject(controlPlane), controlPlane)
 	if errors.IsNotFound(err) {
-		// If we don't find the `KubeadmControlPlane` we assume it's a managed control plane cluster and expect 0 control plane nodes
+		// If we don't find the `KubeadmControlPlane` we assume it's a managed control plane cluster and return a nil
+		// pointer without error.
 		return nil, nil
 	} else if err != nil {
 		return nil, err

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/go-openapi/jsonpointer v0.20.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.22.4 // indirect
+	github.com/gobuffalo/flect v1.0.2 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
@@ -118,6 +119,7 @@ require (
 	github.com/monochromegane/go-gitignore v0.0.0-20200626010858-205db1a8cc00 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/onsi/gomega v1.27.2 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0-rc2.0.20221005185240-3a7f492d3f1b // indirect
 	github.com/pelletier/go-toml v1.9.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LB
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/gobuffalo/flect v1.0.2 h1:eqjPGSo2WmjgY2XlpGwo2NXgL3RucAKo4k4qQMNA5sA=
+github.com/gobuffalo/flect v1.0.2/go.mod h1:A5msMlrHtLqh9umBSnvabjsMrCcCpAyzglnDvkbYKHs=
 github.com/gobuffalo/logger v1.0.6 h1:nnZNpxYo0zx+Aj9RfMPBm+x9zAU2OayFh/xrAWi34HU=
 github.com/gobuffalo/logger v1.0.6/go.mod h1:J31TBEHR1QLV2683OXTAItYIg8pv2JMHnF/quuAbMjs=
 github.com/gobuffalo/packd v1.0.1 h1:U2wXfRr4E9DH8IdsDLlRFwTZTK7hLfq9qT/QHXGVe/0=

--- a/pkg/wait/conditions.go
+++ b/pkg/wait/conditions.go
@@ -207,7 +207,7 @@ func IsAppVersion(ctx context.Context, kubeClient *client.Client, appName string
 	}
 }
 
-// IsClusterConditionSet returns a WaitCondition that checks if a Cluster resource has the specified condition with the expected status
+// IsClusterConditionSet returns a WaitCondition that checks if a Cluster resource has the specified condition with the expected status.
 func IsClusterConditionSet(ctx context.Context, kubeClient *client.Client, clusterName string, clusterNamespace string, conditionType capi.ConditionType, expectedStatus corev1.ConditionStatus, expectedReason string) WaitCondition {
 	cluster := &capi.Cluster{
 		ObjectMeta: v1.ObjectMeta{
@@ -219,7 +219,7 @@ func IsClusterConditionSet(ctx context.Context, kubeClient *client.Client, clust
 	return isClusterApiObjectConditionSet(ctx, kubeClient, cluster, conditionType, expectedStatus, expectedReason)
 }
 
-// IsKubeadmControlPlaneConditionSet returns a WaitCondition that checks if a KubeadmControlPlane resource has the specified condition with the expected status
+// IsKubeadmControlPlaneConditionSet returns a WaitCondition that checks if a KubeadmControlPlane resource has the specified condition with the expected status.
 func IsKubeadmControlPlaneConditionSet(ctx context.Context, kubeClient *client.Client, clusterName string, clusterNamespace string, conditionType capi.ConditionType, expectedStatus corev1.ConditionStatus, expectedReason string) WaitCondition {
 	kcp := &kubeadm.KubeadmControlPlane{
 		ObjectMeta: v1.ObjectMeta{
@@ -231,8 +231,7 @@ func IsKubeadmControlPlaneConditionSet(ctx context.Context, kubeClient *client.C
 	return isClusterApiObjectConditionSet(ctx, kubeClient, kcp, conditionType, expectedStatus, expectedReason)
 }
 
-// IsKubeadmControlPlaneConditionSet returns a WaitCondition that checks if a cluster has the specified condition with the expected status
-// Passing Kind explicitly here for the sake of more useful logs (as obj.GetObjectKind().GroupVersionKind().Kind returns empty string sometimes)
+// isClusterApiObjectConditionSet returns a WaitCondition that checks if a cluster has the specified condition with the expected status.
 func isClusterApiObjectConditionSet(ctx context.Context, kubeClient *client.Client, obj clusterApiObject, conditionType capi.ConditionType, expectedStatus corev1.ConditionStatus, expectedReason string) WaitCondition {
 	return func() (bool, error) {
 		if err := kubeClient.Client.Get(ctx, cr.ObjectKeyFromObject(obj), obj); err != nil {


### PR DESCRIPTION
This PR adds the following new `WaitCondition` funcs:
- `IsClusterConditionSet` checks if Cluster resource has a condition set with specified status and reason
- `IsKubeadmControlPlaneConditionSet` checks if KubeadmControlPlane resource has a condition set with specified status and reason

And also:
- `GetKubeadmControlPlane` that returns KubeadmControlPlane resource that is used in cluster-test-suites to do checks with KubeadmControlPlane resource

These will be then used in cluster-test-suites suites to:
- check if the Cluster has Ready condition with Status=True
- check a control plane rolling update has finished by checking if KubeadmControlPlane has MachinesSpecUpToDate condition with Status=True