### PR TITLE
Switch to using single quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change double quoted log message with single quotes to make them more readable when displayed in the json output of Ginkgo
+
 ## [0.19.0] - 2024-05-06
 
 ### Changed

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -97,7 +97,7 @@ func NewWithContext(kubeconfigPath string, contextName string) (*Client, error) 
 
 	data, err := os.ReadFile(kubeconfigPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create context from kubeconfig file %q - %v", kubeconfigPath, err)
+		return nil, fmt.Errorf("failed to create context from kubeconfig file '%s' - %v", kubeconfigPath, err)
 	}
 	clusterName, err := getClusterNameFromKubeConfig(data, contextName)
 	if err != nil {

--- a/pkg/client/exec.go
+++ b/pkg/client/exec.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (c *Client) ExecInPod(ctx context.Context, podName, namespace, containerName string, command []string) (string, string, error) {
-	logger.Log("Running %v in container %q in pod %q", command, containerName, podName)
+	logger.Log("Running %v in container '%s' in pod '%s'", command, containerName, podName)
 
 	tty := false
 

--- a/pkg/wait/conditions.go
+++ b/pkg/wait/conditions.go
@@ -156,10 +156,10 @@ func IsAppStatus(ctx context.Context, kubeClient *client.Client, appName string,
 
 		actualStatus := app.Status.Release.Status
 		if expectedStatus == actualStatus {
-			logger.Log("App status for %s is as expected: %s", appName, actualStatus)
+			logger.Log("App status for '%s' is as expected: expectedStatus='%s' actualStatus='%s'", appName, expectedStatus, actualStatus)
 			return true, nil
 		} else {
-			logger.Log("App status for %s is not yet as expected: expectedStatus=%q actualStatus=%q (reason: %q)", appName, expectedStatus, actualStatus, app.Status.Release.Reason)
+			logger.Log("App status for '%s' is not yet as expected: expectedStatus='%s' actualStatus='%s' (reason: '%s')", appName, expectedStatus, actualStatus, app.Status.Release.Reason)
 			return false, nil
 		}
 	}
@@ -186,9 +186,9 @@ func IsAllAppStatus(ctx context.Context, kubeClient *client.Client, appNamespace
 
 			actualStatus := app.Status.Release.Status
 			if expectedStatus == actualStatus {
-				logger.Log("App status for %s is as expected: %s", namespacedName.Name, actualStatus)
+				logger.Log("App status for '%s' is as expected: expectedStatus='%s' actualStatus='%s'", namespacedName.Name, expectedStatus, actualStatus)
 			} else {
-				logger.Log("App status for %s is not yet as expected: expectedStatus=%q actualStatus=%q (reason: %q)", namespacedName.Name, expectedStatus, actualStatus, app.Status.Release.Reason)
+				logger.Log("App status for '%s' is not yet as expected: expectedStatus='%s' actualStatus='%s' (reason: '%s')", namespacedName.Name, expectedStatus, actualStatus, app.Status.Release.Reason)
 				isSuccess = false
 			}
 		}


### PR DESCRIPTION
Switch to using single quotes around variables to make them more readable in the log output in Tekton.

Example of before:

```
  {"level":"info","ts":"2024-05-09T10:54:25Z","msg":"App status for t-42ahb6yuuobyg4o37a-aws-pod-identity-webhook is not yet as expected: expectedStatus=\"deployed\" actualStatus=\"\" (reason: \"\")"}
  {"level":"info","ts":"2024-05-09T10:54:25Z","msg":"App status for t-42ahb6yuuobyg4o37a-capi-node-labeler is as expected: deployed"}
```

Example of after:

```
  {"level":"info","ts":"2024-05-09T10:54:25Z","msg":"App status for 't-42ahb6yuuobyg4o37a-aws-pod-identity-webhook' is not yet as expected: expectedStatus='deployed' actualStatus='' (reason: '')"}
  {"level":"info","ts":"2024-05-09T10:54:25Z","msg":"App status for 't-42ahb6yuuobyg4o37a-capi-node-labeler' is as expected: expectedStatus='deployed' actualStatus='deployed'"}
```