### PR TITLE
Remove DefaultAppsValues struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Change
+
+- Removed `application.DefaultAppsValues` in favour of getting the values from the cluster values instead.
+
 ## [0.19.1] - 2024-05-09
 
 ### Changed

--- a/pkg/application/types.go
+++ b/pkg/application/types.go
@@ -51,12 +51,6 @@ type NodePool struct {
 	Name     *string `yaml:"name"`
 }
 
-// DefaultAppsValues holds common values for default-apps-<provider> charts. These are
-// the provider independent values and are present for all the charts
-type DefaultAppsValues struct {
-	BaseDomain string `yaml:"baseDomain"`
-}
-
 // UnmarshalJSON implements a custom unmarshaller that handles both the old and new schema structures
 func (cv *ClusterValues) UnmarshalJSON(b []byte) error {
 	if strings.Contains(string(b), `"global":`) {


### PR DESCRIPTION
Blocked by:
* https://github.com/giantswarm/cluster-test-suites/pull/291
* https://github.com/giantswarm/ingress-nginx-app/pull/628

Remove the `DefaultAppsValues` struct in favour of using the cluster values instead. The only property it supported was `BaseDomain` which is also already available on the Cluster values.

This goes a small way in making the migration to not having default-apps anymore a little bit easier.