### PR TITLE
Support unified cluster-aws app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for unified cluster-aws app. With cluster-aws v0.76.0 and newer, default apps are deployed with cluster-aws and default-apps-aws app is not deployed anymore.
+
 ## [0.20.1] - 2024-05-13
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace (
 )
 
 require (
+	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/giantswarm/apiextensions-application v0.6.0
 	github.com/giantswarm/kubectl-gs/v2 v2.45.0
 	github.com/giantswarm/organization-operator v1.6.0
@@ -35,7 +36,6 @@ require (
 	github.com/BurntSushi/toml v1.2.1 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
 	github.com/Masterminds/squirrel v1.5.3 // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -326,6 +326,7 @@ func (a *Application) IsUnifiedClusterAppWithDefaultApps() (bool, error) {
 				}
 			}
 		}
+		appVersionString = strings.TrimPrefix(appVersionString, "v")
 		appVersion, err := semver.StrictNewVersion(appVersionString)
 		if err != nil {
 			return false, err

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	templateapp "github.com/giantswarm/kubectl-gs/v2/pkg/template/app"
 	corev1 "k8s.io/api/core/v1"
@@ -305,4 +306,44 @@ func (a *Application) GetInstallNamespace() string {
 		installNamespace = a.Organization.GetNamespace()
 	}
 	return installNamespace
+}
+
+// IsUnifiedClusterAppWithDefaultApps returns a flag that indicates if a cluster-$provider app with specified version is
+// a unified cluster-$provider app that deploys all default apps.
+func (a *Application) IsUnifiedClusterAppWithDefaultApps() (bool, error) {
+	isUnifiedClusterApp := false
+	switch a.AppName {
+	case "cluster-aws":
+		appVersionString := a.Version
+		if appVersionString == "" {
+			var ok bool
+			appVersionString, ok = getOverrideVersion(a.AppName)
+			if !ok {
+				var err error
+				appVersionString, err = getLatestReleaseVersion(a.AppName)
+				if err != nil {
+					return false, err
+				}
+			}
+		}
+		appVersion, err := semver.StrictNewVersion(appVersionString)
+		if err != nil {
+			return false, err
+		}
+
+		unifiedClusterAppMinVersion := semver.New(0, 76, 0, "", "")
+
+		// desired app version is greater than or equal to the unified cluster app version
+		desiredAppVersionGTEUnified := !unifiedClusterAppMinVersion.GreaterThan(appVersion)
+
+		// desired app version is the dev build on top of unified cluster app version, e.g. unified app version is v0.76.0
+		// and desired version is v0.76.0-37ec0271eb72504378133ae1276c287a6d702e78
+		desiredAppVersionIsUnifiedWithDevChanges := appVersion.Prerelease() != "" &&
+			appVersion.Major() == unifiedClusterAppMinVersion.Major() &&
+			appVersion.Minor() == unifiedClusterAppMinVersion.Minor() &&
+			appVersion.Patch() == unifiedClusterAppMinVersion.Patch()
+
+		isUnifiedClusterApp = desiredAppVersionGTEUnified || desiredAppVersionIsUnifiedWithDevChanges
+	}
+	return isUnifiedClusterApp, nil
 }

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -481,3 +481,89 @@ func TestWithVersion_Catalog(t *testing.T) {
 		t.Errorf("Was expecting catalog to be the provided with the test suffix. Expected: %s, Actual: %s", "override", app.Spec.Catalog)
 	}
 }
+
+func TestIsUnifiedClusterAppWithDefaultApps(t *testing.T) {
+	type testCases struct {
+		description    string
+		appName        string
+		appVersion     string
+		expectedResult bool
+	}
+
+	for _, scenario := range []testCases{
+		{
+			description:    "cluster-aws v0.76.0 is a unified cluster app",
+			appName:        "cluster-aws",
+			appVersion:     "0.76.0",
+			expectedResult: true,
+		},
+		{
+			description:    "cluster-aws v0.76.0-37ec0271eb72504378133ae1276c287a6d702e78 is a unified cluster app with change on top of it",
+			appName:        "cluster-aws",
+			appVersion:     "0.76.0-37ec0271eb72504378133ae1276c287a6d702e78",
+			expectedResult: true,
+		},
+		{
+			description:    "cluster-aws v0.76.1 is a unified cluster app",
+			appName:        "cluster-aws",
+			appVersion:     "0.76.1",
+			expectedResult: true,
+		},
+		{
+			description:    "cluster-aws v0.77.0 is a unified cluster app",
+			appName:        "cluster-aws",
+			appVersion:     "0.77.0",
+			expectedResult: true,
+		},
+		{
+			description:    "cluster-aws v0.75.0 is not a unified cluster app",
+			appName:        "cluster-aws",
+			appVersion:     "0.75.0",
+			expectedResult: false,
+		},
+		{
+			description:    "cluster-aws v0.75.1 is not a unified cluster app",
+			appName:        "cluster-aws",
+			appVersion:     "0.75.1",
+			expectedResult: false,
+		},
+		{
+			description:    "cluster-azure is not a unified cluster app",
+			appName:        "cluster-azure",
+			appVersion:     "v0.100.0",
+			expectedResult: false,
+		},
+		{
+			description:    "cluster-vsphere is not a unified cluster app",
+			appName:        "cluster-vsphere",
+			appVersion:     "v0.100.0",
+			expectedResult: false,
+		},
+		{
+			description:    "cluster-cloud-director is not a unified cluster app",
+			appName:        "cluster-cloud-director",
+			appVersion:     "v0.100.0",
+			expectedResult: false,
+		},
+	} {
+		t.Run(scenario.description, func(t *testing.T) {
+			app := &Application{
+				AppName: scenario.appName,
+				Version: scenario.appVersion,
+			}
+
+			result, err := app.IsUnifiedClusterAppWithDefaultApps()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if result != scenario.expectedResult {
+				if scenario.expectedResult {
+					t.Errorf("Expected cluster app to be a unified cluster app, but it wasn't.")
+				} else {
+					t.Errorf("Expected cluster app not to be a unified cluster app, but it was.")
+				}
+			}
+		})
+	}
+}

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -150,3 +150,9 @@ func (c *Cluster) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, *applica
 func (c *Cluster) GetNamespace() string {
 	return c.Organization.GetNamespace()
 }
+
+// UsesUnifiedClusterApp returns a flag that indicates if the cluster is deployed with the unified cluster-$provider app
+// that deploys all default apps.
+func (c *Cluster) UsesUnifiedClusterApp() (bool, error) {
+	return c.ClusterApp.IsUnifiedClusterAppWithDefaultApps()
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3119

With cluster-aws v0.76.0 and newer, default apps are deployed with cluster-aws and default-apps-aws app is not deployed anymore.

Note: The latest cluster-aws release is v0.75.0 and the [default apps addition](https://github.com/giantswarm/cluster-aws/pull/581) is not yet merged (but it has been tested and it's ready to be merged). This PR assumes that the [default apps addition](https://github.com/giantswarm/cluster-aws/pull/581) will be merged and that v0.76.0 will be released.