### PR TITLE
Include PipelineRun and Taskrun name in App labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- If relevant env vars are found populate the Cluster Apps and Org CRs with labels containing the Tekton run names
+
 ## [0.21.0] - 2024-05-14
 
 ### Added

--- a/pkg/application/utils.go
+++ b/pkg/application/utils.go
@@ -77,3 +77,14 @@ func getOverrideVersion(app string) (string, bool) {
 	ver := getOverrideVersions()[strings.ToLower(app)]
 	return ver, ver != ""
 }
+
+func mergeMaps(m1 map[string]string, m2 map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range m1 {
+		merged[k] = v
+	}
+	for key, value := range m2 {
+		merged[key] = value
+	}
+	return merged
+}

--- a/pkg/organization/organization.go
+++ b/pkg/organization/organization.go
@@ -2,6 +2,7 @@ package organization
 
 import (
 	"fmt"
+	"os"
 	"strings"
 
 	templateorg "github.com/giantswarm/kubectl-gs/v2/pkg/template/organization"
@@ -67,6 +68,15 @@ func (o *Org) Build() (*orgv1alpha1.Organization, error) {
 	// This check will allow us to re-use existing orgs too without accidentally deleting the org when done
 	orgCR.ObjectMeta.Annotations = map[string]string{
 		DeleteAnnotation: "true",
+	}
+
+	// If found, populate details about Tekton run as labels
+	orgCR.ObjectMeta.Labels = map[string]string{}
+	if os.Getenv("TEKTON_PIPELINE_RUN") != "" {
+		orgCR.ObjectMeta.Labels["cicd.giantswarm.io/pipelinerun"] = os.Getenv("TEKTON_PIPELINE_RUN")
+	}
+	if os.Getenv("TEKTON_TASK_RUN") != "" {
+		orgCR.ObjectMeta.Labels["cicd.giantswarm.io/taskrun"] = os.Getenv("TEKTON_TASK_RUN")
 	}
 
 	orgCR.Status.Namespace = o.GetNamespace()


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26830
Blocked by: https://github.com/giantswarm/tekton-resources/pull/343

If specific Tekton env vars are found we'll populate labels on App and Org CRs to point to the relevant PipelineRun and TaskRun to make it easier to find out what test run created what resources.