### PR TITLE
Added new ApplyBuiltCluster framework function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a new `ApplyBuiltCluster` function to the framework to avoid building a Cluster twice if the result types are needed in testing. This helps to ensure that the Release generated is the same as applied in the case where `cluster.Build()` is called within a test case to access the generated properties.
+
 ## [1.0.1] - 2024-06-13
 
 ### Fixed

--- a/framework.go
+++ b/framework.go
@@ -160,7 +160,7 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 	return cluster, nil
 }
 
-// ApplyCluster takes a Cluster object, applies it to the MC in the correct order and then waits for a valid Kubeconfig to be available
+// ApplyCluster takes a Cluster object, builds it, then applies it to the MC in the correct order and then waits for a valid Kubeconfig to be available
 //
 // A timeout can be provided via the given `ctx` value by using `context.WithTimeout()`
 //
@@ -178,13 +178,29 @@ func (f *Framework) ApplyCluster(ctx context.Context, cluster *application.Clust
 		return nil, fmt.Errorf("failed to build cluster app: %v", err)
 	}
 
+	return f.ApplyBuiltCluster(ctx, builtCluster)
+}
+
+// ApplyBuiltCluster takes a pre-built Cluster object, applies it to the MC in the correct order and then waits for a valid Kubeconfig to be available
+//
+// A timeout can be provided via the given `ctx` value by using `context.WithTimeout()`
+//
+// Example:
+//
+//	timeoutCtx, cancelTimeout := context.WithTimeout(context.Background(), 20*time.Minute)
+//	defer cancelTimeout()
+//
+//	cluster := application.NewClusterApp(utils.GenerateRandomName("t"), application.ProviderAWS)
+//	builtCluster, _ := cluster.Build()
+//	client, err := framework.ApplyBuiltCluster(timeoutCtx, builtCluster)
+func (f *Framework) ApplyBuiltCluster(ctx context.Context, builtCluster *application.BuiltCluster) (*client.Client, error) {
 	if builtCluster.Release != nil {
 		if err := f.MC().CreateOrUpdate(ctx, builtCluster.Release); err != nil {
 			return nil, fmt.Errorf("failed to apply release resources: %v", err)
 		}
 	}
 
-	err = f.CreateOrg(ctx, cluster.Organization)
+	err := f.CreateOrg(ctx, builtCluster.SourceCluster.Organization)
 	if err != nil {
 		return nil, err
 	}
@@ -200,7 +216,7 @@ func (f *Framework) ApplyCluster(ctx context.Context, cluster *application.Clust
 		}
 	}
 
-	kubeClient, err := f.WaitForClusterReady(ctx, cluster.Name, cluster.GetNamespace())
+	kubeClient, err := f.WaitForClusterReady(ctx, builtCluster.SourceCluster.Name, builtCluster.SourceCluster.GetNamespace())
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +228,7 @@ func (f *Framework) ApplyCluster(ctx context.Context, cluster *application.Clust
 	}
 
 	// Store the WC client for use in the tests
-	f.wcClients[cluster.Name] = testClient
+	f.wcClients[builtCluster.SourceCluster.Name] = testClient
 
 	return testClient, nil
 }

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -30,9 +30,10 @@ type AppPair struct {
 }
 
 type BuiltCluster struct {
-	Cluster     *AppPair
-	DefaultApps *AppPair
-	Release     *releases.Release
+	SourceCluster *Cluster
+	Cluster       *AppPair
+	DefaultApps   *AppPair
+	Release       *releases.Release
 }
 
 // Provider is the supported cluster provider name used to determine the cluster and default-apps to use
@@ -142,7 +143,9 @@ func (c *Cluster) UsesUnifiedClusterApp() (bool, error) {
 // Build defaults and populates some required values on the apps then generated the App and Configmap pairs for both the
 // cluster and default-apps (if applicable) apps as well as the Release CR.
 func (c *Cluster) Build() (*BuiltCluster, error) {
-	builtCluster := &BuiltCluster{}
+	builtCluster := &BuiltCluster{
+		SourceCluster: c,
+	}
 
 	baseLabels := getBaseLabels()
 


### PR DESCRIPTION
Added a new `ApplyBuiltCluster` function that allows building a `BuiltCluster` within a test case and then having that applied to the MC instead of re-building it within `ApplyCluster`. This allows us to use `cluster.Build()` within the upgrade test and ensure that the values we're referencing in the test case are the same as being applied to the MC.