### PR TITLE
Add support for Release override env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support the `E2E_RELEASE_VERSION` and `E2E_RELEASE_COMMIT` environment variables to control what base Release to use
+
+### Changed
+
+- Refactored all supported environment variables into their own module
+
 ## [1.6.0] - 2024-06-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ The following environment variables can be set to control or override different 
 | `E2E_WC_NAME` | The name of an existing Workload Cluster to load from the Management Cluster instead of creating a new one.<br/>Must be used with `E2E_WC_NAMESPACE` |
 | `E2E_WC_NAMESPACE` | The namespace an existing Workload Cluster is in which will be loaded instead of creating a new one.<br/>Must be used with `E2E_WC_NAME` |
 | `E2E_OVERRIDE_VERSIONS` | Sets the version of Apps to use instead of installing the latest released.<br/>Example format: `E2E_OVERRIDE_VERSIONS="cluster-aws=0.38.0-5f4372ac697fce58d524830a985ede2082d7f461"` |
+| `E2E_RELEASE_VERSION` | The base Release version to use when creating the Workload Cluster.<br/>Must be used with `E2E_RELEASE_COMMIT` |
+| `E2E_RELEASE_COMMIT` | The git commit from the `releases` repo that contains the Release version to use when creating the Workload Cluster.<br/>Must be used with `E2E_RELEASE_VERSION` |
+
+All of these can be found in [`./pkg/env/const.go`](./pkg/env/const.go).
 
 ## Documentation
 

--- a/framework.go
+++ b/framework.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/giantswarm/clustertest/pkg/application"
 	"github.com/giantswarm/clustertest/pkg/client"
+	"github.com/giantswarm/clustertest/pkg/env"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/organization"
 	"github.com/giantswarm/clustertest/pkg/testuser"
@@ -27,12 +28,6 @@ import (
 	cr "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	EnvKubeconfig               = "E2E_KUBECONFIG"
-	EnvWorkloadClusterName      = "E2E_WC_NAME"
-	EnvWorkloadClusterNamespace = "E2E_WC_NAMESPACE"
-)
-
 // Framework is the overall framework for testing of clusters
 type Framework struct {
 	mcKubeconfigPath string
@@ -42,9 +37,9 @@ type Framework struct {
 
 // New initializes a new Framework instance using the provided context from the kubeconfig found in the env var `E2E_KUBECONFIG`
 func New(contextName string) (*Framework, error) {
-	mcKubeconfig, ok := os.LookupEnv(EnvKubeconfig)
+	mcKubeconfig, ok := os.LookupEnv(env.Kubeconfig)
 	if !ok {
-		return nil, fmt.Errorf("no %s set", EnvKubeconfig)
+		return nil, fmt.Errorf("no %s set", env.Kubeconfig)
 	}
 
 	mcClient, err := client.NewWithContext(mcKubeconfig, contextName)
@@ -93,8 +88,8 @@ func (f *Framework) WC(clusterName string) (*client.Client, error) {
 //	}
 func (f *Framework) LoadCluster() (*application.Cluster, error) {
 	ctx := context.Background()
-	name := os.Getenv(EnvWorkloadClusterName)
-	namespace := os.Getenv(EnvWorkloadClusterNamespace)
+	name := os.Getenv(env.WorkloadClusterName)
+	namespace := os.Getenv(env.WorkloadClusterNamespace)
 	org := organization.NewFromNamespace(namespace)
 
 	if name == "" || namespace == "" {

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/giantswarm/clustertest/pkg/env"
 	"github.com/giantswarm/clustertest/pkg/organization"
 )
 
@@ -172,7 +173,7 @@ func TestMustWithValuesFile(t *testing.T) {
 
 func TestWithVersion_Override(t *testing.T) {
 	overrideVersion := "v9.9.9"
-	os.Setenv("E2E_OVERRIDE_VERSIONS", fmt.Sprintf("cluster-aws=%s", overrideVersion))
+	os.Setenv(env.OverrideVersions, fmt.Sprintf("cluster-aws=%s", overrideVersion))
 
 	// Test successful override
 	app, _, err := New("installName", "cluster-aws").WithVersion("").Build()

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -3,6 +3,7 @@ package application
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
@@ -10,6 +11,7 @@ import (
 	releases "github.com/giantswarm/releases/sdk/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/giantswarm/clustertest/pkg/env"
 	"github.com/giantswarm/clustertest/pkg/logger"
 	"github.com/giantswarm/clustertest/pkg/organization"
 	"github.com/giantswarm/clustertest/pkg/utils"
@@ -205,6 +207,17 @@ func (c *Cluster) Build() (*BuiltCluster, error) {
 			releaseBuilder, err := releasesapi.NewBuilder(releaseClient, provider, "")
 			if err != nil {
 				return builtCluster, err
+			}
+
+			overrideReleaseVersion := os.Getenv(env.ReleaseVersion)
+			if overrideReleaseVersion != "" {
+				overrideReleaseCommit := os.Getenv(env.ReleaseCommit)
+				if overrideReleaseCommit == "" {
+					return nil, fmt.Errorf("'%s' was set without also setting '%s'", env.ReleaseVersion, env.ReleaseCommit)
+				}
+
+				// TODO: Load release from PR commit. Not sure if this will return an image builder or a release object.
+
 			}
 
 			releaseBuilder = releaseBuilder.

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -226,8 +226,8 @@ func (c *Cluster) Build() (*BuiltCluster, error) {
 					return builtCluster, err
 				}
 
-				// TODO: Override the release name with a unique suffix to avoid conflicts
-
+				// Override the release name with a unique suffix to avoid conflicts
+				release.Name = fmt.Sprintf("%s-%s", release.Name, strings.TrimPrefix(utils.GenerateRandomName("r"), "r-"))
 			} else {
 				releaseBuilder = releaseBuilder.
 					// Ensure release has a unique name

--- a/pkg/application/utils.go
+++ b/pkg/application/utils.go
@@ -8,6 +8,8 @@ import (
 
 	"dario.cat/mergo"
 	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/clustertest/pkg/env"
 )
 
 // TemplateValues is the properties made available to the Values string when templating.
@@ -57,12 +59,10 @@ func parseTemplate(manifest string, config *TemplateValues) (string, error) {
 	return manifestBuffer.String(), nil
 }
 
-const VersionOverrideEnvVar = "E2E_OVERRIDE_VERSIONS"
-
 func getOverrideVersions() map[string]string {
 	versions := map[string]string{}
 
-	overrides := os.Getenv(VersionOverrideEnvVar)
+	overrides := os.Getenv(env.OverrideVersions)
 	if overrides != "" {
 		overridesList := strings.Split(overrides, ",")
 		for _, pair := range overridesList {

--- a/pkg/env/const.go
+++ b/pkg/env/const.go
@@ -1,0 +1,26 @@
+package env
+
+const (
+	// Kubeconfig is the environment variable pointing to the kubeconfig file that
+	// will be used to connect to the MC
+	Kubeconfig = "E2E_KUBECONFIG"
+
+	// WorkloadClusterName is the environment variable containing the name of the
+	// WC to load instead of creating a new one
+	WorkloadClusterName = "E2E_WC_NAME"
+	// WorkloadClusterNamespace is the environment variable containing the namespace
+	// that the WC to load is in
+	WorkloadClusterNamespace = "E2E_WC_NAMESPACE"
+
+	// OverrideVersions is the environment variable containing App versions to use
+	// instead of the latest release.
+	// This is a comma separated list in the format `app-name=version-number`
+	// E.g. `cluster-aws=v1.2.3`
+	OverrideVersions = "E2E_OVERRIDE_VERSIONS"
+
+	// ReleaseVersion is the name of the release to use instead of the latest
+	ReleaseVersion = "E2E_RELEASE_VERSION"
+	// ReleaseCommit is the git commit from the `giantswarm/releases` repo to
+	// fetch the release from
+	ReleaseCommit = "E2E_RELEASE_COMMIT"
+)


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3477

Example output:

```
E2E_RELEASE_VERSION=aws-25.0.0-mntest.3 E2E_RELEASE_COMMIT=522aa35f2e7d9576147cb1bad70b44ec7b323df7 E2E_KUBECONFIG=~/.kube/clusters/e2e.yaml ginkgo --timeout 4h -v -r ./providers/capa/standard/
  
Running Suite: CAPA Standard Suite - /Users/marcus/Code/GiantSwarm/cluster-test-suites/providers/capa/standard
==============================================================================================================

Will run 32 of 32 specs
------------------------------
[BeforeSuite] 
/Users/marcus/Code/GiantSwarm/cluster-test-suites/internal/suite/setup.go:25
  {"level":"info","ts":"2024-06-25T15:53:58+01:00","msg":"Workload cluster name: t-oxu827vi4m3j2xz3v1"}
  {"level":"info","ts":"2024-06-25T15:53:58+01:00","msg":"Organisation name: t-j7vbvgdo89obrt1bzr"}
  {"level":"info","ts":"2024-06-25T15:53:58+01:00","msg":"Checking connection to MC is available."}
  {"level":"info","ts":"2024-06-25T15:53:58+01:00","msg":"MC API Endpoint: 'https://api.grizzly.gaws.gigantic.io:443'"}
  {"level":"info","ts":"2024-06-25T15:53:58+01:00","msg":"MC name: 'grizzly'"}
  {"level":"info","ts":"2024-06-25T15:53:59+01:00","msg":"Cluster App is supported by Releases"}
  {"level":"info","ts":"2024-06-25T15:53:59+01:00","msg":"Release name: 'aws-25.0.0-mntest.3.avhy1kvmll8f9gjx9o'"}
  {"level":"info","ts":"2024-06-25T15:53:59+01:00","msg":"Waiting for Namespace 'org-t-j7vbvgdo89obrt1bzr' to be created"}
```

Example created Release CR:

```
$ k get release aws-25.0.0-mntest.3.avhy1kvmll8f9gjx9o -o yaml
apiVersion: release.giantswarm.io/v1alpha1
kind: Release
metadata:
  annotations:
    ci.giantswarm.io/release-commit: 522aa35f2e7d9576147cb1bad70b44ec7b323df7
    ci.giantswarm.io/release-version: 25.0.0-mntest.3
    e2e-test-cleanup: "true"
  creationTimestamp: "2024-06-25T14:53:59Z"
  generation: 1
  labels:
    giantswarm.io/cluster: t-oxu827vi4m3j2xz3v1
  name: aws-25.0.0-mntest.3.avhy1kvmll8f9gjx9o
[...]
```