### PR TITLE
Added extra logging to node ready check when condition fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Extra logging when `checkNodesReady` fails condition check that shows the current node taints.
+
 ## [1.3.0] - 2024-06-20
 
 ### Added

--- a/pkg/wait/conditions.go
+++ b/pkg/wait/conditions.go
@@ -334,6 +334,10 @@ func checkNodesReady(ctx context.Context, kubeClient *client.Client, condition f
 		}
 
 		if condition(readyNodes) {
+			for _, node := range nodes.Items {
+				logger.Log("Node status: NodeName='%s', Taints='%v'", node.ObjectMeta.Name, node.Spec.Taints)
+			}
+
 			return false, nil
 		}
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31013

Adds some extra logging that will display the taints of all current nodes being checked against so the actual progress of the nodes can be seen in the test logs.

### Example output

```
  {"level":"info","ts":"2024-06-20T10:27:14+01:00","msg":"Checking for ready nodes"}
  {"level":"info","ts":"2024-06-20T10:27:14+01:00","msg":"2 nodes ready, expecting 3"}
  {"level":"info","ts":"2024-06-20T10:27:14+01:00","msg":"Node status: NodeName='ip-10-0-108-44.eu-west-2.compute.internal', Taints='[{node-role.kubernetes.io/control-plane  NoSchedule <nil>}]'"}
  {"level":"info","ts":"2024-06-20T10:27:14+01:00","msg":"Node status: NodeName='ip-10-0-147-166.eu-west-2.compute.internal', Taints='[{node-role.kubernetes.io/control-plane  NoSchedule <nil>} {node.kubernetes.io/not-ready  NoSchedule <nil>} {node.kubernetes.io/not-ready  NoExecute 2024-06-20 10:26:29 +0100 BST}]'"}
  {"level":"info","ts":"2024-06-20T10:27:14+01:00","msg":"Node status: NodeName='ip-10-0-249-239.eu-west-2.compute.internal', Taints='[{node-role.kubernetes.io/control-plane  NoSchedule <nil>}]'"}
  {"level":"info","ts":"2024-06-20T10:27:29+01:00","msg":"Checking for ready nodes"}
```