### PR TITLE
Added helpers for logs and pods in deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a helper function to get the logs from a given Pod
+- Added a helper function to get all pods for a given Deployment
+
 ## [1.8.0] - 2024-06-27
 
 ### Added

--- a/pkg/client/logs.go
+++ b/pkg/client/logs.go
@@ -1,0 +1,35 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+// GetLogs fetches the logs from the provided Pod. If `numOfLines` is provided (instead of `nil`) then that
+// many lines will be returned from the end of the logs.
+func (c *Client) GetLogs(ctx context.Context, pod *corev1.Pod, numOfLines *int64) (string, error) {
+	coreClient, err := kubernetes.NewForConfig(c.config)
+	if err != nil {
+		return "", fmt.Errorf("failed initializing kubernetes core client - %v", err)
+	}
+
+	req := coreClient.CoreV1().Pods(pod.ObjectMeta.Namespace).GetLogs(pod.ObjectMeta.Name, &corev1.PodLogOptions{TailLines: numOfLines})
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error in opening log stream - %v", err)
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", fmt.Errorf("error in copying from podLogs to buffer - %v", err)
+	}
+
+	return buf.String(), nil
+}

--- a/pkg/client/logs_test.go
+++ b/pkg/client/logs_test.go
@@ -1,0 +1,56 @@
+package client
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestGetLogs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kube-apiserver-test-cluster-control-plane", // This is a static pod in the kind cluster
+			Namespace: "kube-system",
+		},
+	}
+
+	// Testing against Kind cluster
+	c, err := New(kindKubeconfig)
+	if err != nil {
+		t.Errorf("Not expecting an error to be returned - %v", err)
+	}
+	if c == nil {
+		t.Errorf("Was expecting a client to be returned")
+	}
+
+	logs, err := c.GetLogs(context.Background(), pod, nil)
+	if err != nil {
+		t.Errorf("Not expecting an error to be returned - %v", err)
+	}
+
+	if logs == "" {
+		t.Errorf("Was expecting some logs to be returned but instead got an empty string")
+	}
+
+	numOfLines := int64(5)
+	logs, err = c.GetLogs(context.Background(), pod, &numOfLines)
+	if err != nil {
+		t.Errorf("Not expecting an error to be returned - %v", err)
+	}
+
+	if logs == "" {
+		t.Errorf("Was expecting some logs to be returned but instead got an empty string")
+	}
+
+	actualLines := int64(len(strings.Split(logs, "\n")) - 1) // Minus 1 because of the final trailing newline
+	if actualLines != numOfLines {
+		t.Errorf("Unexpected number of lines returned - Expected=%d, Actual=%d", numOfLines, actualLines)
+	}
+}


### PR DESCRIPTION
Added a couple new helper functions:
* Get all pods associated with a given Deployment
* Get logs from a given Pod