### PR TITLE
Added `failurehandler` package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added a helper function to get the logs from a given Pod
 - Added a helper function to get all pods for a given Deployment
+- Added new `failurehandlers` package to provide extra debugging when Gomega assertions fail - includes the first helper `AppIssues` to be used to debug why Apps might not be installed correctly
 
 ## [1.8.0] - 2024-06-27
 

--- a/pkg/failurehandler/apps.go
+++ b/pkg/failurehandler/apps.go
@@ -19,6 +19,8 @@ func AppIssues(ctx context.Context, framework *clustertest.Framework, cluster *a
 	return Wrap(func() {
 		logger.Log("Attempting to get debug info for App related failure")
 
+		// Note: This doesn't check the MCs own app-operator so issues with bundles won't be surfaced by this.
+
 		maxLines := int64(25)
 
 		{

--- a/pkg/failurehandler/apps.go
+++ b/pkg/failurehandler/apps.go
@@ -1,0 +1,118 @@
+package failurehandler
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AppIssues produces debugging information from app-operator (on the MC) and chart-operator (on the WC)
+// This function will log out the status of the deployments, any related Events found and the last 25 lines of logs from the pods.
+func AppIssues(ctx context.Context, framework *clustertest.Framework, cluster *application.Cluster) FailureHandler {
+	return Wrap(func() {
+		logger.Log("Attempting to get debug info for App related failure")
+
+		maxLines := int64(25)
+
+		{
+			appOperatorName := fmt.Sprintf("%s-app-operator", cluster.Name)
+			logger.Log("Checking '%s' on Management Cluster", appOperatorName)
+
+			mcClient := framework.MC()
+
+			appOperator := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appOperatorName,
+					Namespace: cluster.Organization.GetNamespace(),
+				},
+			}
+			err := mcClient.Get(ctx, ctrl.ObjectKeyFromObject(appOperator), appOperator)
+			if err != nil {
+				logger.Log("Failed to get app-operator Deployment for workload cluster - %v", err)
+				return
+			}
+			logger.Log("Deployment 'app-operator' status - Name='%s', Replicas='%d', ObservedGeneration='%d'", appOperator.ObjectMeta.Name, appOperator.Status.ReadyReplicas, appOperator.Status.ObservedGeneration)
+
+			events, err := mcClient.GetEventsForResource(ctx, appOperator)
+			if err != nil {
+				logger.Log("Failed to get Events for app-operator Deployment - %v", err)
+				return
+			}
+
+			for _, event := range events.Items {
+				logger.Log("App-operator Event: Reason='%s', Message='%s', Last Occurred='%v'", event.Reason, event.Message, event.LastTimestamp)
+			}
+
+			pods, err := mcClient.GetPodsForDeployment(ctx, appOperator)
+			if err != nil {
+				logger.Log("Failed to get Pods for app-operator Deployment - %v", err)
+				return
+			}
+
+			for i := range pods.Items {
+				pod := pods.Items[i]
+				logs, err := mcClient.GetLogs(ctx, &pod, &maxLines)
+				if err != nil {
+					logger.Log("Failed to get Pod logs for Pod '%s' - %v", pod.ObjectMeta.Name, err)
+				}
+				logger.Log("Last %d lines of logs from '%s' - %s", maxLines, pod.ObjectMeta.Name, logs)
+			}
+		}
+
+		{
+			logger.Log("Checking 'chart-operator' on Workload Cluster")
+
+			wcClient, err := framework.WC(cluster.Name)
+			if err != nil {
+				logger.Log("Failed to get client for workload cluster - %v", err)
+				return
+			}
+
+			chartOperator := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "chart-operator",
+					Namespace: "giantswarm",
+				},
+			}
+
+			err = wcClient.Get(ctx, ctrl.ObjectKeyFromObject(chartOperator), chartOperator)
+			if err != nil {
+				logger.Log("Failed to get chart-operator Deployment - %v", err)
+				return
+			}
+			logger.Log("Deployment 'chart-operator' status - Name='%s', Replicas='%d', ObservedGeneration='%d'", chartOperator.ObjectMeta.Name, chartOperator.Status.ReadyReplicas, chartOperator.Status.ObservedGeneration)
+
+			events, err := wcClient.GetEventsForResource(ctx, chartOperator)
+			if err != nil {
+				logger.Log("Failed to get Events for chart-operator Deployment - %v", err)
+				return
+			}
+
+			for _, event := range events.Items {
+				logger.Log("Chart-operator Event: Reason='%s', Message='%s', Last Occurred='%v'", event.Reason, event.Message, event.LastTimestamp)
+			}
+
+			pods, err := wcClient.GetPodsForDeployment(ctx, chartOperator)
+			if err != nil {
+				logger.Log("Failed to get Pods for chart-operator Deployment - %v", err)
+				return
+			}
+
+			for i := range pods.Items {
+				pod := pods.Items[i]
+				logs, err := wcClient.GetLogs(ctx, &pod, &maxLines)
+				if err != nil {
+					logger.Log("Failed to get Pod logs for Pod '%s' - %v", pod.ObjectMeta.Name, err)
+				}
+				logger.Log("Last %d lines of logs from '%s' - %s", maxLines, pod.ObjectMeta.Name, logs)
+			}
+		}
+	})
+}

--- a/pkg/failurehandler/doc.go
+++ b/pkg/failurehandler/doc.go
@@ -1,0 +1,12 @@
+// package failurehandler provides functions to help with extra debugging when Gomega assertions fail
+//
+// # Example using Gomega's `Eventually`
+//
+//	Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
+//			WithTimeout(timeout).
+//			WithPolling(10*time.Second).
+//			Should(
+//				BeTrue(),
+//				failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
+//			)
+package failurehandler

--- a/pkg/failurehandler/types.go
+++ b/pkg/failurehandler/types.go
@@ -1,0 +1,13 @@
+package failurehandler
+
+// FailureHandler is a function that can be used with Gomega to perform extra debugging when an assertion fails
+// Note: Needs to be `interface{}` for Gomega to accept this alias type
+type FailureHandler interface{}
+
+// Wrap returns a valid FailureHandler for the given function
+func Wrap(fn func()) FailureHandler {
+	return func() string {
+		fn()
+		return ""
+	}
+}


### PR DESCRIPTION
Adds a new package to be used with Gomega assertions to perform extra debugging when they fail.

Example:

```
Eventually(wait.IsAllAppDeployed(state.GetContext(), state.GetFramework().MC(), appNamespacedNames)).
		WithTimeout(timeout).
		WithPolling(10*time.Second).
		Should(
			BeTrue(),
			failurehandler.AppIssues(state.GetContext(), state.GetFramework(), state.GetCluster()),
		)
```

Example result (with long logs removed for brevity)

```
{"level":"info","ts":"2024-06-28T11:36:53+01:00","msg":"Attempting to get debug info for App related failure"}
{"level":"info","ts":"2024-06-28T11:36:53+01:00","msg":"Checking 't-rn2nxm3pxapqevel8f-app-operator' on Management Cluster"}
{"level":"info","ts":"2024-06-28T11:36:53+01:00","msg":"Deployment 'app-operator' status - Name='t-rn2nxm3pxapqevel8f-app-operator', Replicas='1', ObservedGeneration='1'"}
{"level":"info","ts":"2024-06-28T11:36:53+01:00","msg":"App-operator Event: Reason='ScalingReplicaSet', Message='Scaled up replica set t-rn2nxm3pxapqevel8f-app-operator-554c4485dc to 1', Last Occurred='2024-06-28 11:22:19 +0100 BST'"}
{"level":"info","ts":"2024-06-28T11:36:54+01:00","msg":"Last 25 lines of logs from 't-rn2nxm3pxapqevel8f-app-operator-554c4485dc-bpb4r' - [REMOVED]"}
{"level":"info","ts":"2024-06-28T11:36:54+01:00","msg":"Checking 'chart-operator' on Workload Cluster"}
{"level":"info","ts":"2024-06-28T11:36:54+01:00","msg":"Deployment 'chart-operator' status - Name='chart-operator', Replicas='1', ObservedGeneration='1'"}
{"level":"info","ts":"2024-06-28T11:36:54+01:00","msg":"Chart-operator Event: Reason='ScalingReplicaSet', Message='Scaled up replica set chart-operator-65bf89b4d5 to 1', Last Occurred='2024-06-28 11:31:37 +0100 BST'"}
{"level":"info","ts":"2024-06-28T11:36:54+01:00","msg":"Last 25 lines of logs from 'chart-operator-65bf89b4d5-ggqsl' - [REMOVED]"}
[FAILED] in [It] - /Users/marcus/Code/GiantSwarm/cluster-test-suites/internal/common/apps.go:71 @ 06/28/24 11:36:54.617
• [FAILED] [61.422 seconds]
Common tests default apps [It] all default apps are deployed without issues
/Users/marcus/Code/GiantSwarm/cluster-test-suites/internal/common/apps.go:27

[FAILED] Timed out after 60.001s.

Expected
    <bool>: false
to be true
In [It] at: /Users/marcus/Code/GiantSwarm/cluster-test-suites/internal/common/apps.go:71 @ 06/28/24 11:36:54.617
```