### PR TITLE
Refactor release handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactored Release handling to support upgrade logic similar to `E2E_OVERRIDE_VERSIONS`
+
 ## [1.9.0] - 2024-06-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following environment variables can be set to control or override different 
 | `E2E_OVERRIDE_VERSIONS` | Sets the version of Apps to use instead of installing the latest released.<br/>Example format: `E2E_OVERRIDE_VERSIONS="cluster-aws=0.38.0-5f4372ac697fce58d524830a985ede2082d7f461"` |
 | `E2E_RELEASE_VERSION` | The base Release version to use when creating the Workload Cluster.<br/>Must be used with `E2E_RELEASE_COMMIT` |
 | `E2E_RELEASE_COMMIT` | The git commit from the `releases` repo that contains the Release version to use when creating the Workload Cluster.<br/>Must be used with `E2E_RELEASE_VERSION` |
+| `E2E_RELEASE_PRE_UPGRADE` | Intended to be used in E2E tests to indicate what Release version to make use of before performing an upgade to a newer Release. Note: not used within this codebase but exposed for use by tests. |
 
 All of these can be found in [`./pkg/env/const.go`](./pkg/env/const.go).
 

--- a/pkg/env/const.go
+++ b/pkg/env/const.go
@@ -23,4 +23,8 @@ const (
 	// ReleaseCommit is the git commit from the `giantswarm/releases` repo to
 	// fetch the release from
 	ReleaseCommit = "E2E_RELEASE_COMMIT"
+
+	// ReleasePreUpgradeVersion is intended to be used in E2E tests to indicate what
+	// Release version to make use of before performing an upgade to a newer Release.
+	ReleasePreUpgradeVersion = "E2E_RELEASE_PRE_UPGRADE"
 )


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3537

Refactor the way Releases are handled in code to allow for more complex version overriding logic. 
This change introduces 3 possible states that can be handled:
1. The release version is set to `""` - This will make use of the environment variable overrides if found or default to the latest version
2. The release version is set to `latest` - This will instruct the code not to use the env vars and instead always use the latest released version
3. The release version is set to a specific value (and commit sha) - Use that version, usually from a PR on the releases repo

This brings the logic inline with how `E2E_OVERRIDE_VERSIONS` is handled and allows us to build support for upgrade tests.