### PR TITLE
Added the E2E_WC_KEEP env var constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `E2E_WC_KEEP` environment variable constant
+
 ## [1.10.0] - 2024-07-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The following environment variables can be set to control or override different 
 | `E2E_KUBECONFIG` | Points to the file containing the kubeconfig to use for the Management Clusters |
 | `E2E_WC_NAME` | The name of an existing Workload Cluster to load from the Management Cluster instead of creating a new one.<br/>Must be used with `E2E_WC_NAMESPACE` |
 | `E2E_WC_NAMESPACE` | The namespace an existing Workload Cluster is in which will be loaded instead of creating a new one.<br/>Must be used with `E2E_WC_NAME` |
+| `E2E_WC_KEEP` | This environment variable is used to indicate that the workload cluster should not be deleted at the end of a test run. Note: not used within this codebase but exposed for use by other tooling. |
 | `E2E_OVERRIDE_VERSIONS` | Sets the version of Apps to use instead of installing the latest released.<br/>Example format: `E2E_OVERRIDE_VERSIONS="cluster-aws=0.38.0-5f4372ac697fce58d524830a985ede2082d7f461"` |
 | `E2E_RELEASE_VERSION` | The base Release version to use when creating the Workload Cluster.<br/>Must be used with `E2E_RELEASE_COMMIT` |
 | `E2E_RELEASE_COMMIT` | The git commit from the `releases` repo that contains the Release version to use when creating the Workload Cluster.<br/>Must be used with `E2E_RELEASE_VERSION` |

--- a/pkg/env/const.go
+++ b/pkg/env/const.go
@@ -12,6 +12,11 @@ const (
 	// that the WC to load is in
 	WorkloadClusterNamespace = "E2E_WC_NAMESPACE"
 
+	// KeepWorkloadCluster is used to indicate if the teardown of the workload cluster
+	// should be skipped. Setting this env var to any non-empty value will ensure the
+	// cluster is kept at the end of a test run.
+	KeepWorkloadCluster = "E2E_WC_KEEP" //nolint:gosec
+
 	// OverrideVersions is the environment variable containing App versions to use
 	// instead of the latest release.
 	// This is a comma separated list in the format `app-name=version-number`


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31134

Note, this env var is already used by cluster-standup-teardown but is being moved here for consistency and documentation purposes.