### PR TITLE
Added dns and http clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added new DNS resolver client
+- Added new HTTP Client
+
 ## [1.10.1] - 2024-07-04
 
 ### Fixed

--- a/pkg/net/const.go
+++ b/pkg/net/const.go
@@ -1,0 +1,9 @@
+package net
+
+import "time"
+
+const (
+	ProxyEnvVar   string        = "HTTP_PROXY"
+	Nameserver    string        = "8.8.4.4:53"
+	DialerTimeout time.Duration = time.Millisecond * time.Duration(10000)
+)

--- a/pkg/net/dns.go
+++ b/pkg/net/dns.go
@@ -1,0 +1,37 @@
+package net
+
+import (
+	"context"
+	"net"
+	"net/url"
+	"os"
+
+	"github.com/giantswarm/clustertest/pkg/logger"
+)
+
+// NewResovler returns an initialized Resolver that uses an external nameserver to help avoid negative caching
+func NewResolver() *net.Resolver {
+	return &net.Resolver{
+		PreferGo:     true,
+		StrictErrors: true,
+		Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+			if os.Getenv(ProxyEnvVar) != "" {
+				u, err := url.Parse(os.Getenv(ProxyEnvVar))
+				if err != nil {
+					logger.Log("Error parsing %s as a URL %s", ProxyEnvVar, os.Getenv(ProxyEnvVar))
+				} else {
+					if address == u.Host {
+						// always use coredns for proxy address resolution.
+						var d net.Dialer
+						return d.Dial(network, address)
+					}
+				}
+			}
+
+			d := net.Dialer{
+				Timeout: DialerTimeout,
+			}
+			return d.DialContext(ctx, "udp", Nameserver)
+		},
+	}
+}

--- a/pkg/net/dns.go
+++ b/pkg/net/dns.go
@@ -9,7 +9,7 @@ import (
 	"github.com/giantswarm/clustertest/pkg/logger"
 )
 
-// NewResovler returns an initialized Resolver that uses an external nameserver to help avoid negative caching
+// NewResolver returns an initialized Resolver that uses an external nameserver to help avoid negative caching
 func NewResolver() *net.Resolver {
 	return &net.Resolver{
 		PreferGo:     true,

--- a/pkg/net/httpclient.go
+++ b/pkg/net/httpclient.go
@@ -1,0 +1,32 @@
+package net
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"os"
+
+	"github.com/giantswarm/clustertest/pkg/logger"
+)
+
+// NewHttpClient returns an initialized HTTP Client that uses an external nameserver to help avoid negative caching
+// and if detected will make use of any proxy found in the environment
+func NewHttpClient() *http.Client {
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			dialer := &net.Dialer{
+				Resolver: NewResolver(),
+			}
+			return dialer.DialContext(ctx, network, addr)
+		},
+	}
+
+	if os.Getenv(ProxyEnvVar) != "" {
+		logger.Log("Detected need to use PROXY as %s env var was set to %s", ProxyEnvVar, os.Getenv(ProxyEnvVar))
+		transport.Proxy = http.ProxyFromEnvironment
+	}
+
+	return &http.Client{
+		Transport: transport,
+	}
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31135

Make an initialised DNS and HTTP client available to be used within tests. An external nameserver is configured in both to help avoid negative DNS caching and the http client will make use of the proxy if one is detected.