### PR TITLE
Moved ShouldSkipUpgrade from cluster-test-suites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Moved `ShouldSkipUpgrade` from cluster-test-suites so it can be reused by cluster-standup-teardown also.
+
 ## [1.11.1] - 2024-07-04
 
 ### Fixed

--- a/pkg/utils/upgrade.go
+++ b/pkg/utils/upgrade.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"os"
+	"strings"
+
+	"github.com/giantswarm/clustertest/pkg/env"
+)
+
+// ShouldSkipUpgrade checks for the required environment variables needed to run the upgrade test suite
+func ShouldSkipUpgrade() bool {
+	overrideVersions := strings.TrimSpace(os.Getenv(env.OverrideVersions))
+	releaseVersion := strings.TrimSpace(os.Getenv(env.ReleaseVersion))
+
+	if overrideVersions == "" && releaseVersion == "" {
+		return true
+	}
+
+	return false
+}


### PR DESCRIPTION
We need to also use `ShouldSkipUpgrade` in `cluster-standup-teardown` so i'm moving it into here to be able to be referenced from both repos.