### PR TITLE
Added failurehandlers for Deployments, STS and DaemonSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changed
+
+- The `failurehandler.AppIssues` function no longer takes in a context and instead creates its own to ensure it isn't passed in an already timed-out context
+
+### Added
+
+- New failurehandler functions: `DeploymentsNotReady`, `DaemonSetsNotReady` & `StatefulSetsNotReady`
+- Added `GetPodsForStatefulSet` and `GetPodsForDaemonSet` to client
+
 ## [1.12.0] - 2024-07-05
 
 ### Added

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -391,3 +391,37 @@ func (c *Client) GetPodsForDeployment(ctx context.Context, deployment *appsv1.De
 
 	return pods, nil
 }
+
+// GetPodsForStatefulSet returns a list of Pods that match the given StatefulSet selector
+func (c *Client) GetPodsForStatefulSet(ctx context.Context, statefulset *appsv1.StatefulSet) (*corev1.PodList, error) {
+	pods := &corev1.PodList{}
+
+	selector, err := metav1.LabelSelectorAsSelector(statefulset.Spec.Selector)
+	if err != nil {
+		return pods, err
+	}
+
+	err = c.List(ctx, pods, cr.MatchingLabelsSelector{Selector: selector})
+	if err != nil {
+		return pods, err
+	}
+
+	return pods, nil
+}
+
+// GetPodsForDaemonSet returns a list of Pods that match the given DaemonSet selector
+func (c *Client) GetPodsForDaemonSet(ctx context.Context, daemonset *appsv1.DaemonSet) (*corev1.PodList, error) {
+	pods := &corev1.PodList{}
+
+	selector, err := metav1.LabelSelectorAsSelector(daemonset.Spec.Selector)
+	if err != nil {
+		return pods, err
+	}
+
+	err = c.List(ctx, pods, cr.MatchingLabelsSelector{Selector: selector})
+	if err != nil {
+		return pods, err
+	}
+
+	return pods, nil
+}

--- a/pkg/failurehandler/apps.go
+++ b/pkg/failurehandler/apps.go
@@ -1,7 +1,6 @@
 package failurehandler
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/giantswarm/clustertest"
@@ -15,8 +14,11 @@ import (
 
 // AppIssues produces debugging information from app-operator (on the MC) and chart-operator (on the WC)
 // This function will log out the status of the deployments, any related Events found and the last 25 lines of logs from the pods.
-func AppIssues(ctx context.Context, framework *clustertest.Framework, cluster *application.Cluster) FailureHandler {
+func AppIssues(framework *clustertest.Framework, cluster *application.Cluster) FailureHandler {
 	return Wrap(func() {
+		ctx, cancel := newContext()
+		defer cancel()
+
 		logger.Log("Attempting to get debug info for App related failure")
 
 		// Note: This doesn't check the MCs own app-operator so issues with bundles won't be surfaced by this.

--- a/pkg/failurehandler/context.go
+++ b/pkg/failurehandler/context.go
@@ -1,0 +1,14 @@
+package failurehandler
+
+import (
+	"context"
+	"time"
+)
+
+const contextTimeout = 5 * time.Minute
+
+// newContext returns a new context object with a timeout of 5 minutes to use while gathering failure debug details
+func newContext() (context.Context, context.CancelFunc) {
+	ctx := context.Background()
+	return context.WithTimeout(ctx, contextTimeout)
+}

--- a/pkg/failurehandler/daemonsets.go
+++ b/pkg/failurehandler/daemonsets.go
@@ -1,0 +1,67 @@
+package failurehandler
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+)
+
+// DaemonSetsNotReady collects debug information for all DaemonSets in the workload cluster that currently don't
+// have the expected number of replicas. This information includes events for the DaemonSets and the status of any
+// associated pods.
+func DaemonSetsNotReady(framework *clustertest.Framework, cluster *application.Cluster) FailureHandler {
+	return Wrap(func() {
+		ctx, cancel := newContext()
+		defer cancel()
+
+		logger.Log("Attempting to get debug info for non-ready DaemonSets")
+
+		wcClient, err := framework.WC(cluster.Name)
+		if err != nil {
+			logger.Log("Failed to get client for workload cluster - %v", err)
+			return
+		}
+
+		daemonSetsList := &appsv1.DaemonSetList{}
+		err = wcClient.List(ctx, daemonSetsList)
+		if err != nil {
+			logger.Log("Failed to get list of daemonsets")
+			return
+		}
+
+		for i := range daemonSetsList.Items {
+			daemonset := daemonSetsList.Items[i]
+			available := daemonset.Status.CurrentNumberScheduled
+			desired := daemonset.Status.DesiredNumberScheduled
+			if available != desired {
+				{
+					// Events
+					events, err := wcClient.GetEventsForResource(ctx, &daemonset)
+					if err != nil {
+						logger.Log("Failed to get events for DaemonSet '%s' - %v", daemonset.ObjectMeta.Name, err)
+					} else {
+						for _, event := range events.Items {
+							logger.Log("DaemonSet '%s' Event: Reason='%s', Message='%s', Last Occurred='%v'", daemonset.ObjectMeta.Name, event.Reason, event.Message, event.LastTimestamp)
+						}
+					}
+				}
+				{
+					// Pods
+					pods, err := wcClient.GetPodsForDaemonSet(ctx, &daemonset)
+					if err != nil {
+						logger.Log("Failed to get Pods for DaemonSet '%s' - %v", daemonset.ObjectMeta.Name, err)
+					} else {
+						for _, pod := range pods.Items {
+							logger.Log("Pod '%s' status: Phase='%s'", pod.ObjectMeta.Name, pod.Status.Phase)
+							for _, condition := range pod.Status.Conditions {
+								logger.Log("Pod '%s' condition: Type='%s', Status='%s', Message='%s'", pod.ObjectMeta.Name, condition.Type, condition.Status, condition.Message)
+							}
+						}
+					}
+				}
+			}
+		}
+	})
+}

--- a/pkg/failurehandler/deployments.go
+++ b/pkg/failurehandler/deployments.go
@@ -1,0 +1,67 @@
+package failurehandler
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+)
+
+// DeploymentsNotReady collects debug information for all deployments in the workload cluster that currently don't
+// have the expected number of replicas. This information includes events for the deployment and the status of any
+// associated pods.
+func DeploymentsNotReady(framework *clustertest.Framework, cluster *application.Cluster) FailureHandler {
+	return Wrap(func() {
+		ctx, cancel := newContext()
+		defer cancel()
+
+		logger.Log("Attempting to get debug info for non-ready Deployments")
+
+		wcClient, err := framework.WC(cluster.Name)
+		if err != nil {
+			logger.Log("Failed to get client for workload cluster - %v", err)
+			return
+		}
+
+		deploymentList := &appsv1.DeploymentList{}
+		err = wcClient.List(ctx, deploymentList)
+		if err != nil {
+			logger.Log("Failed to get list of deployments")
+			return
+		}
+
+		for i := range deploymentList.Items {
+			deployment := deploymentList.Items[i]
+			available := deployment.Status.AvailableReplicas
+			desired := *deployment.Spec.Replicas
+			if available != desired {
+				{
+					// Events
+					events, err := wcClient.GetEventsForResource(ctx, &deployment)
+					if err != nil {
+						logger.Log("Failed to get events for Deployment '%s' - %v", deployment.ObjectMeta.Name, err)
+					} else {
+						for _, event := range events.Items {
+							logger.Log("Deployment '%s' Event: Reason='%s', Message='%s', Last Occurred='%v'", deployment.ObjectMeta.Name, event.Reason, event.Message, event.LastTimestamp)
+						}
+					}
+				}
+				{
+					// Pods
+					pods, err := wcClient.GetPodsForDeployment(ctx, &deployment)
+					if err != nil {
+						logger.Log("Failed to get Pods for Deployment '%s' - %v", deployment.ObjectMeta.Name, err)
+					} else {
+						for _, pod := range pods.Items {
+							logger.Log("Pod '%s' status: Phase='%s'", pod.ObjectMeta.Name, pod.Status.Phase)
+							for _, condition := range pod.Status.Conditions {
+								logger.Log("Pod '%s' condition: Type='%s', Status='%s', Message='%s'", pod.ObjectMeta.Name, condition.Type, condition.Status, condition.Message)
+							}
+						}
+					}
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION

Added:
- New failurehandler functions: `DeploymentsNotReady`, `DaemonSetsNotReady` & `StatefulSetsNotReady`
- Added `GetPodsForStatefulSet` and `GetPodsForDaemonSet` to client

> [!WARNING]
> This PR introduces a breaking change to the `AppIssues` function to no longer take in a Context object. Even with this I plan to release this as a minor release and will be fixing the only place this code is used immediately after this is released.