### PR TITLE
Support overriding default apps in Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed `isShaVersion` regex to also allow for versions with pre-release suffix already (e.g. `-gs3`)
+
+### Changed
+
+- Replaced `getLatestReleaseVersion` with `GetLatestAppVersion`
+- Log output of release name now handled in `Build` instead of `GetRelease`
+
+### Added
+
+- Added `IsDefaultApp` to Cluster to allow checking if a given App is a default app installed for that cluster
+- Added `WithAppOverride` to Cluster to allow overriding default apps included on a Release (note: only supports providers that have moved to Releases already)
+
 ## [1.14.0] - 2024-07-08
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/google/go-github/v63 v63.0.0
 	github.com/mittwald/go-helm-client v0.12.10
 	golang.org/x/oauth2 v0.21.0
+	golang.org/x/text v0.16.0
 	k8s.io/api v0.30.3
 	k8s.io/apimachinery v0.30.3
 	k8s.io/client-go v0.30.3
@@ -156,7 +157,6 @@ require (
 	golang.org/x/sync v0.7.0 // indirect
 	golang.org/x/sys v0.21.0 // indirect
 	golang.org/x/term v0.21.0 // indirect
-	golang.org/x/text v0.16.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240624140628-dc46fd24d27d // indirect

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -23,7 +23,7 @@ const (
 )
 
 // If commit SHA based version we'll change the catalog
-var isShaVersion = regexp.MustCompile(`(?m)^v?[0-9]+\.[0-9]+\.[0-9]+\-\w{40}`)
+var isShaVersion = regexp.MustCompile(`(?m)^v?[0-9]+\.[0-9]+\.[0-9]+(\-\w+)?\-\w{40}`)
 
 func init() {
 	_ = applicationv1alpha1.AddToScheme(scheme.Scheme)
@@ -223,7 +223,7 @@ func (a *Application) Build() (*applicationv1alpha1.App, *corev1.ConfigMap, erro
 		}
 		fallthrough
 	case "latest":
-		latestVersion, err := getLatestReleaseVersion(a.RepoName)
+		latestVersion, err := GetLatestAppVersion(a.RepoName)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -331,7 +331,7 @@ func (a *Application) IsUnifiedClusterAppWithDefaultApps() (bool, error) {
 		appVersionString, ok = getOverrideVersion(a.AppName)
 		if !ok {
 			var err error
-			appVersionString, err = getLatestReleaseVersion(a.AppName)
+			appVersionString, err = GetLatestAppVersion(a.AppName)
 			if err != nil {
 				return false, err
 			}

--- a/pkg/application/defaultAppsValues.go
+++ b/pkg/application/defaultAppsValues.go
@@ -1,0 +1,55 @@
+package application
+
+import (
+	"strings"
+
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+	"sigs.k8s.io/yaml"
+)
+
+func getAppValuesName(appName string) string {
+	parts := strings.Split(appName, "-")
+	for i := range parts {
+		if i > 0 {
+			parts[i] = cases.Title(language.English, cases.Compact).String(parts[i])
+		}
+	}
+
+	return strings.Join(parts, "")
+}
+
+func buildDefaultAppValues(defaultApp Application) string {
+	// If App doesn't have any custom values don't bother generating any return values
+	if strings.TrimSpace(defaultApp.Values) == "" {
+		return ""
+	}
+
+	type Values map[string]interface{}
+	type AppValues struct {
+		Values Values `json:"values"`
+	}
+	type Apps map[string]AppValues
+	type Global struct {
+		Apps Apps `json:"apps"`
+	}
+	type GlobalAppValues struct {
+		Global Global `json:"global"`
+	}
+	var defaultAppValues Values
+	_ = yaml.Unmarshal([]byte(defaultApp.Values), &defaultAppValues)
+
+	globalValues := GlobalAppValues{
+		Global: Global{
+			Apps: Apps{
+				getAppValuesName(defaultApp.AppName): AppValues{
+					Values: defaultAppValues,
+				},
+			},
+		},
+	}
+
+	out, _ := yaml.Marshal(globalValues)
+
+	return string(out)
+}

--- a/pkg/application/github.go
+++ b/pkg/application/github.go
@@ -26,12 +26,12 @@ func newGitHubClient(ctx context.Context) *github.Client {
 	return github.NewClient(ghHTTPClient)
 }
 
-// getLatestReleaseVersion returns the latest version (tag) name for a given repos release.
+// GetLatestAppVersion returns the latest version (tag) name for a given repos release.
 //
 // This function attempts to check for repos both with and without the `-app` suffix of the provided `applicationName`.
 // The provided `applicationName` is used as preference when looking up releases but if fails will fallback to the
 // suffix variation.
-func getLatestReleaseVersion(applicationName string) (string, error) {
+func GetLatestAppVersion(applicationName string) (string, error) {
 	ctx := context.Background()
 	gh := newGitHubClient(ctx)
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3095

- Fixed `isShaVersion` regex to also allow for versions with pre-release suffix already (e.g. `-gs3`)
- Replaced `getLatestReleaseVersion` with `GetLatestAppVersion` so it can be used outside of the module
- Log output of release name now handled in `Build` instead of `GetRelease` so `GetRelease` can be called in tests without causing confusing logs (as name is unique each time)
- Added `IsDefaultApp` to Cluster to allow checking if a given App is a default app installed for that cluster
- Added `WithAppOverride` to Cluster to allow overriding default apps included on a Release (note: only supports providers that have moved to Releases already)