### PR TITLE
More resilient check for kubeconfig secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed `IsClusterReadyCondition` to no longer return an error when failed to lookup kubeconfig secret due to possibly transient network errors, instead returns `false, nil` with logging of the error so a retry can be performed. Now also checks if `ctx` has timed out.
+
 ## [1.16.2] - 2024-07-26
 
 ### Fixed


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/30463

No longer return an error if failed to get kubeconfig secret for something like a network blip. Instead log out the error and return `false` so it can be retried on the next iteration. The check also not ensures that the provided context hasn't already expired.

Example output:
```

  {"level":"info","ts":"2024-08-06T08:11:14+01:00","msg":"kubeconfig secret not yet available"}
  {"level":"info","ts":"2024-08-06T08:11:24+01:00","msg":"Checking for valid Kubeconfig for cluster t-tz4qffdzjugds8degi"}
  {"level":"info","ts":"2024-08-06T08:11:24+01:00","msg":"kubeconfig secret not yet available"}
  {"level":"info","ts":"2024-08-06T08:11:34+01:00","msg":"Checking for valid Kubeconfig for cluster t-tz4qffdzjugds8degi"}
  {"level":"info","ts":"2024-08-06T08:12:09+01:00","msg":"Error occurred while trying to get kubeconfig secret - Get \"https://10.205.9.6:6443/api/v1/namespaces/org-t-n3e8jj9ml1mxl8ht7w/secrets/t-tz4qffdzjugds8degi-kubeconfig\": http2: client connection lost"}
  {"level":"info","ts":"2024-08-06T08:12:19+01:00","msg":"Checking for valid Kubeconfig for cluster t-tz4qffdzjugds8degi"}
  {"level":"info","ts":"2024-08-06T08:12:23+01:00","msg":"Error occurred while trying to get kubeconfig secret - Get \"https://10.205.9.6:6443/api/v1/namespaces/org-t-n3e8jj9ml1mxl8ht7w/secrets/t-tz4qffdzjugds8degi-kubeconfig\": dial tcp 10.205.9.6:6443: connect: network is unreachable"}
  {"level":"info","ts":"2024-08-06T08:12:33+01:00","msg":"Checking for valid Kubeconfig for cluster t-tz4qffdzjugds8degi"}
  {"level":"info","ts":"2024-08-06T08:12:33+01:00","msg":"kubeconfig secret not yet available"}
```