### PR TITLE
Add support for unified cluster-vsphere app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support for unified cluster-vsphere app. With cluster-aws v0.61.0 and newer, default apps are deployed with cluster-vsphere, and default-apps-vsphere app is not deployed anymore.
+- Add support for unified cluster-vsphere app. With cluster-vsphere v0.61.0 and newer, default apps are deployed with cluster-vsphere, and default-apps-vsphere app is not deployed anymore.
 
 ## [1.19.0] - 2024-08-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for unified cluster-vsphere app. With cluster-aws v0.61.0 and newer, default apps are deployed with cluster-vsphere, and default-apps-vsphere app is not deployed anymore.
+
 ## [1.19.0] - 2024-08-19
 
 ### Added

--- a/pkg/application/app.go
+++ b/pkg/application/app.go
@@ -315,8 +315,9 @@ func (a *Application) IsUnifiedClusterAppWithDefaultApps() (bool, error) {
 
 	// Define a map with the minimum versions for each app
 	minVersions := map[string]*semver.Version{
-		"cluster-aws":   semver.New(0, 76, 0, "", ""),
-		"cluster-azure": semver.New(0, 14, 0, "", ""),
+		"cluster-aws":     semver.New(0, 76, 0, "", ""),
+		"cluster-azure":   semver.New(0, 14, 0, "", ""),
+		"cluster-vsphere": semver.New(0, 61, 0, "", ""),
 	}
 
 	// Check if the app is in the map

--- a/pkg/application/app_test.go
+++ b/pkg/application/app_test.go
@@ -549,8 +549,14 @@ func TestIsUnifiedClusterAppWithDefaultApps(t *testing.T) {
 		{
 			description:    "cluster-vsphere is not a unified cluster app",
 			appName:        "cluster-vsphere",
-			appVersion:     "v0.100.0",
+			appVersion:     "v0.60.0",
 			expectedResult: false,
+		},
+		{
+			description:    "cluster-vsphere is a unified cluster app",
+			appName:        "cluster-vsphere",
+			appVersion:     "v0.61.0",
+			expectedResult: true,
 		},
 		{
 			description:    "cluster-cloud-director is not a unified cluster app",


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3125

> [!CAUTION]
> cluster-vsphere v0.61.0 is not yet released.
> 
> cluster-vsphere v0.61.0 with default apps will be released once [this PR](https://github.com/giantswarm/cluster-vsphere/pull/262) has been merged. Only then clustertest with this change can be used.

Add support for unified cluster-vsphere app. With cluster-vsphere v0.61.0 and newer, default apps are deployed with cluster-vsphere, and default-apps-vsphere app is not deployed anymore.