### PR TITLE
Remove "v" prefix from App Version for Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove prefix from App version override for Releases.
+
 ## [1.21.0] - 2024-08-30
 
 ### Changed

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -202,8 +202,8 @@ func (c *Cluster) GetRelease() (*releases.Release, error) {
 				WithClusterApp(strings.TrimPrefix(clusterApplication.Spec.Version, "v"), clusterApplication.Spec.Catalog)
 
 			for _, overrideApp := range c.appOverrides {
-				logger.Log("Overriding Release app '%s'", overrideApp.AppName)
-				releaseBuilder = releaseBuilder.WithApp(overrideApp.AppName, overrideApp.Version, overrideApp.Catalog, []string{})
+				logger.Log("Overriding Release app '%s' version '%s' from catalog '%s'", overrideApp.AppName, overrideApp.Version, overrideApp.Catalog)
+				releaseBuilder = releaseBuilder.WithApp(overrideApp.AppName, strings.TrimPrefix(overrideApp.Version, "v"), overrideApp.Catalog, []string{})
 			}
 
 			release, err = releaseBuilder.Build(context.Background())


### PR DESCRIPTION
Signed-off-by: Matias Charriere <matias@giantswarm.io>

- Remove `v` prefix from App version for Releases.
- Add app version and catalog to log

Otherwise I get:
```
[FAILED] Unexpected error:
      <*errors.errorString | 0xc000b163d0>: 
      failed to apply release resources: [Release.release.giantswarm.io](http://release.release.giantswarm.io/) "aws-29.2.0-t.bhtzeft1ch" is invalid: spec.apps[7].version: Invalid value: "v0.27.0-3569e5fe41d64e0a07a7ff73308f436ff86ac9b0": spec.apps[7].version in body should match '^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$'
      {
          s: "failed to apply release resources: [Release.release.giantswarm.io](http://release.release.giantswarm.io/) \"aws-29.2.0-t.bhtzeft1ch\" is invalid: spec.apps[7].version: Invalid value: \"v0.27.0-3569e5fe41d64e0a07a7ff73308f436ff86ac9b0\": spec.apps[7].version in body should match '^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$'",
      }
  occurred
  In [BeforeSuite] at: /tmp/go/pkg/mod/github.com/giantswarm/cluster-standup-teardown@v1.19.0/pkg/standup/standup.go:75 @ 09/02/24 09:13:47.87
```