### PR TITLE
Fallback to default context if empty context name provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fallback to the default context in the Kubeconfig if empty context name provided
+
 ## [1.24.1] - 2024-09-19
 
 ### Fixed


### PR DESCRIPTION
This allows using the current framework setup code without having to provide the context to use from the kubeconfig. This will be used for MC testing where the kubeconfig produced by mc-bootstrap is passed through to the test suite and the context name is unknown without extra work.