### PR TITLE
Add a new failure handler for Jobs and allow getting MC as WC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- If attempting to get a WC client that isn't found but matches the name of the MC we'll return the MC Kube client. This helps reuse existing framework functions for testing of MCs without a lot of breaking changes to functions.
+
+### Added
+
+- Added a new `JobsUnsuccessful` failure handler to attempt to get more information about why a cluster has failing Jobs.
+
 ## [1.25.0] - 2024-09-23
 
 ### Added

--- a/framework.go
+++ b/framework.go
@@ -64,6 +64,11 @@ func (f *Framework) MC() *client.Client {
 func (f *Framework) WC(clusterName string) (*client.Client, error) {
 	c, ok := f.wcClients[clusterName]
 	if !ok {
+		if clusterName == f.MC().GetClusterName() {
+			// Looks like we're actually attempting to get the MC, not a WC so we'll return the MC client
+			return f.MC(), nil
+		}
+
 		return nil, fmt.Errorf("workload cluster not found for name %s", clusterName)
 	}
 	return c, nil

--- a/pkg/failurehandler/jobs.go
+++ b/pkg/failurehandler/jobs.go
@@ -1,0 +1,55 @@
+package failurehandler
+
+import (
+	batchv1 "k8s.io/api/batch/v1"
+
+	"github.com/giantswarm/clustertest"
+	"github.com/giantswarm/clustertest/pkg/application"
+	"github.com/giantswarm/clustertest/pkg/logger"
+)
+
+// JobsUnsuccessful collects debug information for all Jobs in the workload cluster that haven't completed
+// successfully. This information includes events for the Jobs and the status of all their conditions
+func JobsUnsuccessful(framework *clustertest.Framework, cluster *application.Cluster) FailureHandler {
+	return Wrap(func() {
+		ctx, cancel := newContext()
+		defer cancel()
+
+		logger.Log("Attempting to get debug info for failed Jobs")
+
+		wcClient, err := framework.WC(cluster.Name)
+		if err != nil {
+			logger.Log("Failed to get client for workload cluster - %v", err)
+			return
+		}
+
+		jobList := &batchv1.JobList{}
+		err = wcClient.List(ctx, jobList)
+		if err != nil {
+			logger.Log("Failed to get list of deployments")
+			return
+		}
+
+		for i := range jobList.Items {
+			job := jobList.Items[i]
+			if job.Status.Succeeded == 0 {
+				logger.Log("Job %s/%s has not succeeded. (Number Failed: '%d')", job.ObjectMeta.Namespace, job.ObjectMeta.Name, job.Status.Failed)
+				for _, condition := range job.Status.Conditions {
+					logger.Log("Job '%s' condition: Type='%s', Status='%s', Message='%s'", job.ObjectMeta.Name, condition.Type, condition.Status, condition.Message)
+				}
+
+				{
+					// Events
+					events, err := wcClient.GetEventsForResource(ctx, &job)
+					if err != nil {
+						logger.Log("Failed to get events for Job '%s' - %v", job.ObjectMeta.Name, err)
+					} else {
+						for _, event := range events.Items {
+							logger.Log("Job '%s' Event: Reason='%s', Message='%s', Last Occurred='%v'", job.ObjectMeta.Name, event.Reason, event.Message, event.LastTimestamp)
+						}
+					}
+				}
+			}
+		}
+	})
+}


### PR DESCRIPTION
This PR adds a new failure handler that will print out more debug info for failed Jobs within the cluster.

This PR also makes a change to the way the framework gets WC clients to allow a fallback to the MC if the cluster name asked for isn't found but matched the name of the MC. This allows us to use a lot of the existing framework function for MC testing without a big refactor right now.