### PR TITLE
Ensure Provider is populated when loading an existing workload cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Enusre the cluster Provider value is populated when loading an existing workload cluster
+
 ## [1.27.2] - 2024-10-03
 
 ### Fixed

--- a/framework.go
+++ b/framework.go
@@ -132,6 +132,7 @@ func (f *Framework) LoadCluster() (*application.Cluster, error) {
 			ConfigMapLabels: clusterValues.Labels,
 		},
 		Organization: org,
+		Provider:     application.ProviderFromClusterApplication(clusterApp),
 	}
 
 	skipDefaultAppsApp, err := cluster.UsesUnifiedClusterApp()

--- a/pkg/application/cluster_app.go
+++ b/pkg/application/cluster_app.go
@@ -52,20 +52,6 @@ type BuiltCluster struct {
 	Release       *releases.Release
 }
 
-// Provider is the supported cluster provider name used to determine the cluster and default-apps to use
-type Provider string
-
-// nolint:revive
-const (
-	ProviderAWS           Provider = "aws"
-	ProviderEKS           Provider = "eks"
-	ProviderGCP           Provider = "gcp"
-	ProviderAzure         Provider = "azure"
-	ProviderCloudDirector Provider = "cloud-director"
-	ProviderOpenStack     Provider = "openstack"
-	ProviderVSphere       Provider = "vsphere"
-)
-
 // NewClusterApp generates a new Cluster object to handle creation of Cluster related apps
 func NewClusterApp(clusterName string, provider Provider) *Cluster {
 	org := organization.NewRandomOrg()

--- a/pkg/application/provider.go
+++ b/pkg/application/provider.go
@@ -1,0 +1,45 @@
+package application
+
+import (
+	"strings"
+
+	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
+)
+
+// Provider is the supported cluster provider name used to determine the cluster and default-apps to use
+type Provider string
+
+// nolint:revive
+const (
+	ProviderAWS           Provider = "aws"
+	ProviderEKS           Provider = "eks"
+	ProviderGCP           Provider = "gcp"
+	ProviderAzure         Provider = "azure"
+	ProviderCloudDirector Provider = "cloud-director"
+	ProviderOpenStack     Provider = "openstack"
+	ProviderVSphere       Provider = "vsphere"
+
+	ProviderUnknown Provider = "UNKNOWN"
+)
+
+// ProviderFromClusterApplication returns the appropriate Provider related to the given cluster app
+func ProviderFromClusterApplication(app *applicationv1alpha1.App) Provider {
+	switch strings.ToLower(app.Spec.Name) {
+	case "cluster-aws":
+		return ProviderAWS
+	case "cluster-eks":
+		return ProviderEKS
+	case "cluster-gcp":
+		return ProviderGCP
+	case "cluster-azure":
+		return ProviderAzure
+	case "cluster-cloud-director":
+		return ProviderCloudDirector
+	case "cluster-openstack":
+		return ProviderOpenStack
+	case "cluster-vsphere":
+		return ProviderVSphere
+	}
+
+	return ProviderUnknown
+}


### PR DESCRIPTION
Fixes: https://github.com/giantswarm/giantswarm/issues/31588

Make sure that the `Provider` field on a loaded Cluster is set based on the cluster app being used by that cluster.

Note: This change also introduces a new `ProviderUnknown` to allow a fallback value to be returned but currently it shouldn't be possible for this value to be used under normal testing.

Manually tested with the `apptest-framework` basic test suite. 

```

{"level":"info","ts":"2024-10-08T11:20:51+01:00","msg":"Overriding 'latest' version to '2.4.0'"}
Running Suite: Basic Test - /Users/marcus/Code/GiantSwarm/apptest-framework/tests/e2e/suites/basic
==================================================================================================
Random Seed: 1728382836

Will run 5 of 5 specs
------------------------------
[BeforeSuite] 
/Users/marcus/Code/GiantSwarm/apptest-framework/pkg/suite/suite.go:141
  {"level":"info","ts":"2024-10-08T11:20:53+01:00","msg":"Using existing cluster t-hhqcyi4jdgrpa1b84r/org-t-3l7izwf36yfgscixs1"}
  {"level":"info","ts":"2024-10-08T11:20:57+01:00","msg":"Creating new workload cluster"}
  {"level":"info","ts":"2024-10-08T11:20:57+01:00","msg":"Workload cluster name: t-hhqcyi4jdgrpa1b84r"}
  {"level":"info","ts":"2024-10-08T11:20:57+01:00","msg":"Organisation name: t-3l7izwf36yfgscixs1"}
  {"level":"info","ts":"2024-10-08T11:20:57+01:00","msg":"Checking connection to MC is available."}
  {"level":"info","ts":"2024-10-08T11:20:57+01:00","msg":"MC API Endpoint: 'https://api.grizzly.gaws.gigantic.io:443'"}
  {"level":"info","ts":"2024-10-08T11:20:57+01:00","msg":"MC name: 'grizzly'"}
  {"level":"info","ts":"2024-10-08T11:21:02+01:00","msg":"Cluster App is supported by Releases"}
  {"level":"info","ts":"2024-10-08T11:21:02+01:00","msg":"Release name: 'aws-29.3.1-t.73tc81kl5g'"}
  {"level":"info","ts":"2024-10-08T11:21:07+01:00","msg":"Checking for valid Kubeconfig for cluster t-hhqcyi4jdgrpa1b84r"}
  {"level":"info","ts":"2024-10-08T11:21:08+01:00","msg":"Got valid kubeconfig!"}
  {"level":"info","ts":"2024-10-08T11:21:09+01:00","msg":"KubeConfig isn't managed by Teleport, generating ServiceAccount in WC to assume"}
  {"level":"info","ts":"2024-10-08T11:21:09+01:00","msg":"Namespace default exists"}
  {"level":"info","ts":"2024-10-08T11:21:11+01:00","msg":"Waiting for 3 control plane nodes to be ready"}
  {"level":"info","ts":"2024-10-08T11:21:11+01:00","msg":"Checking for ready nodes"}
  {"level":"info","ts":"2024-10-08T11:21:12+01:00","msg":"3 nodes ready, expecting 3"}
  {"level":"info","ts":"2024-10-08T11:21:12+01:00","msg":"Waiting for worker nodes to be ready"}
  {"level":"info","ts":"2024-10-08T11:21:12+01:00","msg":"Checking for ready nodes"}
  {"level":"info","ts":"2024-10-08T11:21:12+01:00","msg":"2 nodes ready, expecting 2"}
  {"level":"info","ts":"2024-10-08T11:21:12+01:00","msg":"Waiting for all default apps to be ready"}
```