### PR TITLE
Added Bundle function to using multiple FailureHandlers together

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a `Bundle` function to allow using multiple FailureHandlers together
+
 ## [1.30.2] - 2024-11-07
 
 ### Fixed

--- a/pkg/failurehandler/types.go
+++ b/pkg/failurehandler/types.go
@@ -11,3 +11,12 @@ func Wrap(fn func()) FailureHandler {
 		return ""
 	}
 }
+
+// Bundle allows multiple different FailureHandler functions to be used in a chain
+func Bundle(failureHandlers ...FailureHandler) FailureHandler {
+	return Wrap(func() {
+		for _, fn := range failureHandlers {
+			fn.(func() string)()
+		}
+	})
+}


### PR DESCRIPTION
Needed to be able to cleanly use multiple different FailureHandlers in a single gomega assertion.