### PR TITLE
Improve error message when KubeConfig data not populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Improved error message when KubeConfig data not populated
+
 ## [1.31.0] - 2024-11-28
 
 ### Added

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -269,7 +269,8 @@ func (c *Client) GetClusterKubeConfig(ctx context.Context, clusterName string, c
 // getTeleportKubeConfig retrieves the Kubeconfig from the secret that is created by Teleport tbot on the MC.
 func (c *Client) getTeleportKubeConfig(ctx context.Context, clusterName string, clusterNamespace string) (string, error) {
 	var kubeconfigSecret corev1.Secret
-	err := c.Get(ctx, types.NamespacedName{Name: fmt.Sprintf("teleport-%s-kubeconfig", clusterName), Namespace: clusterNamespace}, &kubeconfigSecret)
+	secretName := fmt.Sprintf("teleport-%s-kubeconfig", clusterName)
+	err := c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: clusterNamespace}, &kubeconfigSecret)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// If not found we will return nothing
@@ -278,7 +279,7 @@ func (c *Client) getTeleportKubeConfig(ctx context.Context, clusterName string, 
 		return "", err
 	}
 	if len(kubeconfigSecret.Data["kubeconfig.yaml"]) == 0 {
-		return "", fmt.Errorf("kubeconfig secret found but data[kubeconfig.yaml] not populated")
+		return "", fmt.Errorf("kubeconfig secret '%s' found in namespace '%s' but data[kubeconfig.yaml] not populated", secretName, clusterNamespace)
 	}
 
 	kubeconfig := clientcmdapi.Config{}


### PR DESCRIPTION
Old message:
```
{"level":"info","ts":"2024-12-03T11:09:45Z","msg":"Error occurred while trying to get kubeconfig secret - kubeconfig secret found but data[kubeconfig.yaml] not populated"}
```

New message:
```
{"level":"info","ts":"2024-12-03T11:09:45Z","msg":"Error occurred while trying to get kubeconfig secret - kubeconfig secret 'teleport-t-XXXX-kubeconfig' found in namespace 'org-t-XXXX' but data[kubeconfig.yaml] not populated"}
```