### PR TITLE
Correctly handle context with deadline set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Correctly handle a context with a deadline within `Wait.For` calls.
+
 ## [1.32.0] - 2025-01-06
 
 ### Fixed


### PR DESCRIPTION
We were previously ignoring any deadline set on the provided context instance. This first checks if one is set and if not then use the timeout.