### PR TITLE
Skip previous major upgrade testing when releasing the first version of a new major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Skip previous major upgrade testing when releasing the first version of a new major (e.g., skip v29→v30 testing when v30.0.0 is the first v30.x release).
+
 ### Changed
 
 - Go: Update dependencies.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3994

This will skip major upgrade tests in case it is the first major release, we already have a pipeline which covers this so we don't run it twice.