### PR TITLE
Add pkg/helmrelease package with builder and wait conditions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3
 	github.com/cert-manager/cert-manager v1.20.2
 	github.com/fluxcd/helm-controller/api v1.5.4
+	github.com/fluxcd/pkg/apis/meta v1.25.1
+	github.com/fluxcd/source-controller/api v1.8.2
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/giantswarm/kubectl-gs/v2 v2.57.0
 	github.com/giantswarm/organization-operator v1.6.4
@@ -16,7 +18,9 @@ require (
 	github.com/mittwald/go-helm-client v0.12.19
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/text v0.36.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.35.4
+	k8s.io/apiextensions-apiserver v0.35.4
 	k8s.io/apimachinery v0.35.4
 	k8s.io/client-go v0.35.4
 	k8s.io/kubectl v0.35.4
@@ -54,8 +58,8 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/exponent-io/jsonpath v0.0.0-20210407135951-1de76d718b3f // indirect
 	github.com/fatih/color v1.19.0 // indirect
+	github.com/fluxcd/pkg/apis/acl v0.9.0 // indirect
 	github.com/fluxcd/pkg/apis/kustomize v1.15.1 // indirect
-	github.com/fluxcd/pkg/apis/meta v1.25.1 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/giantswarm/k8smetadata v0.25.0 // indirect
@@ -156,9 +160,7 @@ require (
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	helm.sh/helm/v3 v3.20.0 // indirect
-	k8s.io/apiextensions-apiserver v0.35.4 // indirect
 	k8s.io/apiserver v0.35.4 // indirect
 	k8s.io/cli-runtime v0.35.4 // indirect
 	k8s.io/cluster-bootstrap v0.35.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -92,10 +92,14 @@ github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fluxcd/helm-controller/api v1.5.4 h1:wbAwD+cSGBZEhT3qq1naBKkitdNbqRtWQUFNA3XTXOc=
 github.com/fluxcd/helm-controller/api v1.5.4/go.mod h1:lTgeUmtVYExMKp7mRDncsr4JwHTz3LFtLjRJZeR98lI=
+github.com/fluxcd/pkg/apis/acl v0.9.0 h1:wBpgsKT+jcyZEcM//OmZr9RiF8klL3ebrDp2u2ThsnA=
+github.com/fluxcd/pkg/apis/acl v0.9.0/go.mod h1:TttNS+gocsGLwnvmgVi3/Yscwqrjc17+vhgYfqkfrV4=
 github.com/fluxcd/pkg/apis/kustomize v1.15.1 h1:t9QZh+3ZS8EKmlxrnnbcKZcGTrg8FDvMF1T8BHMCuqI=
 github.com/fluxcd/pkg/apis/kustomize v1.15.1/go.mod h1:IZOy4CCtR/hxMGb7erK1RfbGnczVv4/dRBoVD37AywI=
 github.com/fluxcd/pkg/apis/meta v1.25.1 h1:WG1GIC/SOz0GjxT0uVuO6AMicQ3yFsk6bDozCnq+fto=
 github.com/fluxcd/pkg/apis/meta v1.25.1/go.mod h1:c7o6mJGLCMvNrfdinGZehkrdZuFT9vZdZNrn66DtVD0=
+github.com/fluxcd/source-controller/api v1.8.2 h1:i0/6BeNCn+zRfX+gKh4PsFF2NBzBhwXt0wPImVlZObg=
+github.com/fluxcd/source-controller/api v1.8.2/go.mod h1:HgZ6NSH1cyOE2jRoNwln1xEwr9ETvrLeiy1o4O04vQM=
 github.com/foxcpp/go-mockdns v1.2.0 h1:omK3OrHRD1IWJz1FuFBCFquhXslXoF17OvBS6JPzZF0=
 github.com/foxcpp/go-mockdns v1.2.0/go.mod h1:IhLeSFGed3mJIAXPH2aiRQB+kqz7oqu8ld2qVbOu7Wk=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,6 +11,7 @@ import (
 
 	certmanager "github.com/cert-manager/cert-manager/pkg/api"
 	helm "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
 	applicationv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	orgv1alpha1 "github.com/giantswarm/organization-operator/api/v1alpha1"
 	releasev1alpha1 "github.com/giantswarm/releases/sdk/api/v1alpha1"
@@ -159,6 +160,7 @@ func newClient(config *rest.Config, clusterName string) (*Client, error) {
 	_ = releasev1alpha1.AddToScheme(client.Scheme())
 	_ = certmanager.AddToScheme(client.Scheme())
 	_ = helm.AddToScheme(client.Scheme())
+	_ = sourcev1beta2.AddToScheme(client.Scheme())
 	_ = gatewayv1.AddToScheme(client.Scheme())
 
 	return &Client{

--- a/pkg/helmrelease/doc.go
+++ b/pkg/helmrelease/doc.go
@@ -1,0 +1,28 @@
+// Package helmrelease provides builders and wait conditions for Flux HelmRelease CRs,
+// mirroring the ergonomics of the application package for Giant Swarm App CRs.
+//
+// # Building a HelmRelease
+//
+// Use [New] to create a builder, chain fluent setters, then call [HelmRelease.Build]:
+//
+//	hr, err := helmrelease.New("my-chart", "my-chart").
+//	    WithNamespace("org-acme").
+//	    WithClusterName(clusterName).
+//	    WithInCluster(false).
+//	    WithValuesFile("values.yaml", &helmrelease.TemplateValues{ClusterName: clusterName}).
+//	    Build()
+//
+// # OCIRepository
+//
+// An OCIRepository must exist before a HelmRelease can reconcile. Use
+// [EnsureOCIRepository] and [DeleteOCIRepository] to manage its lifecycle:
+//
+//	err := helmrelease.EnsureOCIRepository(ctx, client, "my-chart", "org-acme", "my-chart")
+//
+// # Waiting for readiness
+//
+// [IsHelmReleaseReady] and [IsAppOrHelmReleaseReady] return [wait.WaitCondition] values
+// compatible with [wait.For]:
+//
+//	err := wait.For(helmrelease.IsHelmReleaseReady(ctx, mcClient, "my-chart", "org-acme"))
+package helmrelease

--- a/pkg/helmrelease/helmrelease.go
+++ b/pkg/helmrelease/helmrelease.go
@@ -11,10 +11,10 @@ import (
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	fluxmeta "github.com/fluxcd/pkg/apis/meta"
 	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+	"gopkg.in/yaml.v3"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubectlscheme "k8s.io/kubectl/pkg/scheme"
-	"gopkg.in/yaml.v3"
 )
 
 func init() {

--- a/pkg/helmrelease/helmrelease.go
+++ b/pkg/helmrelease/helmrelease.go
@@ -1,0 +1,204 @@
+package helmrelease
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"text/template"
+	"time"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	fluxmeta "github.com/fluxcd/pkg/apis/meta"
+	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	kubectlscheme "k8s.io/kubectl/pkg/scheme"
+	"gopkg.in/yaml.v3"
+)
+
+func init() {
+	_ = helmv2.AddToScheme(kubectlscheme.Scheme)
+	_ = sourcev1beta2.AddToScheme(kubectlscheme.Scheme)
+}
+
+// TemplateValues holds the template variables available when rendering HelmRelease values files.
+type TemplateValues struct {
+	ClusterName string
+	ExtraValues map[string]string
+}
+
+// HelmRelease is a fluent builder for Flux HelmRelease CRs.
+//
+// ClusterName must always be set — it is used for templating values and, when InCluster
+// is false, for naming the kubeconfig secret (<clusterName>-kubeconfig).
+type HelmRelease struct {
+	Name            string
+	Namespace       string
+	ReleaseName     string
+	TargetNamespace string
+	ChartName       string
+	OCIRepoName     string
+	Values          map[string]interface{}
+	// ClusterName is always required. Used for values templating and (when !InCluster)
+	// to locate the <ClusterName>-kubeconfig secret.
+	ClusterName string
+	// InCluster controls the deployment target: true = management cluster (no kubeConfig),
+	// false = workload cluster (kubeConfig from ClusterName secret).
+	InCluster bool
+}
+
+// New creates a new HelmRelease builder for the given chart.
+// Defaults: ReleaseName=name, TargetNamespace=name, OCIRepoName=name, InCluster=false.
+func New(name, chartName string) *HelmRelease {
+	return &HelmRelease{
+		Name:            name,
+		ReleaseName:     name,
+		TargetNamespace: name,
+		OCIRepoName:     name,
+		ChartName:       chartName,
+		InCluster:       false,
+	}
+}
+
+// WithNamespace sets the namespace of the HelmRelease CR itself.
+func (h *HelmRelease) WithNamespace(ns string) *HelmRelease {
+	h.Namespace = ns
+	return h
+}
+
+// WithReleaseName sets the Helm release name (spec.releaseName).
+func (h *HelmRelease) WithReleaseName(name string) *HelmRelease {
+	h.ReleaseName = name
+	return h
+}
+
+// WithTargetNamespace sets the namespace Helm installs into.
+func (h *HelmRelease) WithTargetNamespace(ns string) *HelmRelease {
+	h.TargetNamespace = ns
+	return h
+}
+
+// WithOCIRepoName sets the name of the OCIRepository chartRef.
+func (h *HelmRelease) WithOCIRepoName(name string) *HelmRelease {
+	h.OCIRepoName = name
+	return h
+}
+
+// WithClusterName sets the cluster name used for values templating and kubeconfig secret naming.
+func (h *HelmRelease) WithClusterName(clusterName string) *HelmRelease {
+	h.ClusterName = clusterName
+	return h
+}
+
+// WithInCluster sets whether the HelmRelease targets the management cluster (true)
+// or a workload cluster (false, default).
+func (h *HelmRelease) WithInCluster(inCluster bool) *HelmRelease {
+	h.InCluster = inCluster
+	return h
+}
+
+// WithValues sets the chart values directly.
+func (h *HelmRelease) WithValues(values map[string]interface{}) *HelmRelease {
+	h.Values = values
+	return h
+}
+
+// WithValuesFile reads a YAML file, renders it as a Go template using tv, and sets
+// the result as the chart values.
+func (h *HelmRelease) WithValuesFile(path string, tv *TemplateValues) (*HelmRelease, error) {
+	values, err := parseValuesFile(path, tv)
+	if err != nil {
+		return nil, err
+	}
+	h.Values = values
+	return h, nil
+}
+
+// MustWithValuesFile is like WithValuesFile but panics on error.
+func (h *HelmRelease) MustWithValuesFile(path string, tv *TemplateValues) *HelmRelease {
+	hr, err := h.WithValuesFile(path, tv)
+	if err != nil {
+		panic(err)
+	}
+	return hr
+}
+
+// Build constructs and returns the Flux HelmRelease CR. When InCluster is false,
+// spec.kubeConfig.secretRef is set to <ClusterName>-kubeconfig.
+func (h *HelmRelease) Build() (*helmv2.HelmRelease, error) {
+	rawValues, err := marshalValues(h.Values)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling values: %w", err)
+	}
+
+	hr := &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      h.Name,
+			Namespace: h.Namespace,
+		},
+		Spec: helmv2.HelmReleaseSpec{
+			Interval:         metav1.Duration{Duration: 1 * time.Minute},
+			ReleaseName:      h.ReleaseName,
+			TargetNamespace:  h.TargetNamespace,
+			StorageNamespace: h.TargetNamespace,
+			ChartRef: &helmv2.CrossNamespaceSourceReference{
+				Kind: "OCIRepository",
+				Name: h.OCIRepoName,
+			},
+			Install: &helmv2.Install{
+				CreateNamespace: true,
+				Remediation: &helmv2.InstallRemediation{
+					Retries: 5,
+				},
+			},
+			Values: rawValues,
+		},
+	}
+
+	if !h.InCluster {
+		hr.Spec.KubeConfig = &fluxmeta.KubeConfigReference{
+			SecretRef: &fluxmeta.SecretKeyReference{
+				Name: fmt.Sprintf("%s-kubeconfig", h.ClusterName),
+				Key:  "value",
+			},
+		}
+	}
+
+	return hr, nil
+}
+
+func marshalValues(values map[string]interface{}) (*apiextensionsv1.JSON, error) {
+	if len(values) == 0 {
+		return nil, nil
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+	return &apiextensionsv1.JSON{Raw: raw}, nil
+}
+
+func parseValuesFile(path string, tv *TemplateValues) (map[string]interface{}, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading values file %s: %w", path, err)
+	}
+
+	tmpl, err := template.New("values").Parse(string(data))
+	if err != nil {
+		return nil, fmt.Errorf("parsing values template %s: %w", path, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, tv); err != nil {
+		return nil, fmt.Errorf("executing values template %s: %w", path, err)
+	}
+
+	var values map[string]interface{}
+	if err := yaml.Unmarshal(buf.Bytes(), &values); err != nil {
+		return nil, fmt.Errorf("unmarshalling values from %s: %w", path, err)
+	}
+
+	return values, nil
+}

--- a/pkg/helmrelease/oci_repository.go
+++ b/pkg/helmrelease/oci_repository.go
@@ -1,0 +1,53 @@
+package helmrelease
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	sourcev1beta2 "github.com/fluxcd/source-controller/api/v1beta2"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const ociRegistryURL = "oci://gsoci.azurecr.io/charts/giantswarm"
+
+// EnsureOCIRepository creates an OCIRepository pointing at the Giant Swarm OCI
+// registry for the given chart, or is a no-op if it already exists.
+func EnsureOCIRepository(ctx context.Context, c cr.Client, name, namespace, chartName string) error {
+	repo := &sourcev1beta2.OCIRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: sourcev1beta2.OCIRepositorySpec{
+			URL:      fmt.Sprintf("%s/%s", ociRegistryURL, chartName),
+			Interval: metav1.Duration{Duration: 1 * time.Minute},
+			Reference: &sourcev1beta2.OCIRepositoryRef{
+				SemVer: "*",
+			},
+		},
+	}
+
+	err := c.Create(ctx, repo)
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("creating OCIRepository: %w", err)
+	}
+	return nil
+}
+
+// DeleteOCIRepository deletes the named OCIRepository, or is a no-op if it does not exist.
+func DeleteOCIRepository(ctx context.Context, c cr.Client, name, namespace string) error {
+	repo := &sourcev1beta2.OCIRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	err := c.Delete(ctx, repo)
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/helmrelease/wait.go
+++ b/pkg/helmrelease/wait.go
@@ -2,6 +2,7 @@ package helmrelease
 
 import (
 	"context"
+	"fmt"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
@@ -39,6 +40,38 @@ func IsAppOrHelmReleaseReady(ctx context.Context, c *client.Client, name, namesp
 			return true, nil
 		}
 		return false, nil
+	}
+}
+
+// AreAllReady returns a function that checks whether every HelmRelease in names
+// has a Ready=True condition. Suitable for use with wait.Consistent.
+func AreAllReady(ctx context.Context, c cr.Client, names []types.NamespacedName) func() error {
+	return func() error {
+		allReady := true
+		for _, name := range names {
+			hr := &helmv2.HelmRelease{}
+			if err := c.Get(ctx, name, hr); err != nil {
+				logger.Log("HelmRelease '%s' failed to retrieve: %v", name.Name, err)
+				allReady = false
+				continue
+			}
+
+			condition := apimeta.FindStatusCondition(hr.Status.Conditions, "Ready")
+			switch {
+			case condition == nil:
+				logger.Log("HelmRelease '%s' has no Ready condition yet", name.Name)
+				allReady = false
+			case condition.Status == metav1.ConditionTrue:
+				logger.Log("HelmRelease '%s' is Ready", name.Name)
+			default:
+				logger.Log("HelmRelease '%s' not yet ready: %s - %s", name.Name, condition.Reason, condition.Message)
+				allReady = false
+			}
+		}
+		if !allReady {
+			return fmt.Errorf("not all HelmReleases are ready")
+		}
+		return nil
 	}
 }
 

--- a/pkg/helmrelease/wait.go
+++ b/pkg/helmrelease/wait.go
@@ -1,0 +1,66 @@
+package helmrelease
+
+import (
+	"context"
+
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	cr "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/clustertest/v4/pkg/client"
+	"github.com/giantswarm/clustertest/v4/pkg/logger"
+	"github.com/giantswarm/clustertest/v4/pkg/wait"
+)
+
+// IsHelmReleaseReady returns a WaitCondition that polls the named HelmRelease and
+// becomes true when its Ready condition is True.
+func IsHelmReleaseReady(ctx context.Context, c cr.Client, name, namespace string) wait.WaitCondition {
+	return isHelmReleaseReady(ctx, c, types.NamespacedName{Name: name, Namespace: namespace})
+}
+
+// IsAppOrHelmReleaseReady returns a WaitCondition that becomes true as soon as
+// either an App CR or a HelmRelease with the given name/namespace reaches a Ready
+// state. Use this for default apps that may be deployed as either kind depending on
+// cluster chart version.
+//
+// Get errors (including NotFound) are suppressed so the outer Eventually keeps
+// polling until one of the two kinds appears and is Ready, or the timeout fires.
+func IsAppOrHelmReleaseReady(ctx context.Context, c *client.Client, name, namespace string) wait.WaitCondition {
+	appCheck := wait.IsAppDeployed(ctx, c, name, namespace)
+	hrCheck := isHelmReleaseReady(ctx, c, types.NamespacedName{Name: name, Namespace: namespace})
+
+	return func() (bool, error) {
+		if ok, _ := appCheck(); ok {
+			return true, nil
+		}
+		if ok, _ := hrCheck(); ok {
+			return true, nil
+		}
+		return false, nil
+	}
+}
+
+func isHelmReleaseReady(ctx context.Context, c cr.Client, name types.NamespacedName) wait.WaitCondition {
+	return func() (bool, error) {
+		hr := &helmv2.HelmRelease{}
+		if err := c.Get(ctx, name, hr); err != nil {
+			return false, err
+		}
+
+		condition := apimeta.FindStatusCondition(hr.Status.Conditions, "Ready")
+		if condition == nil {
+			logger.Log("HelmRelease '%s' has no Ready condition yet", name.Name)
+			return false, nil
+		}
+
+		if condition.Status == metav1.ConditionTrue {
+			logger.Log("HelmRelease '%s' is Ready", name.Name)
+			return true, nil
+		}
+
+		logger.Log("HelmRelease '%s' not yet ready: %s - %s", name.Name, condition.Reason, condition.Message)
+		return false, nil
+	}
+}


### PR DESCRIPTION
Introduces a new pkg/helmrelease package that mirrors the ergonomics of
pkg/application but targets Flux HelmRelease CRs instead of Giant Swarm
App CRs. This lets test suites use typed HelmRelease builders and wait
conditions without duplicating helpers in each repo.

- HelmRelease builder type with fluent setters and Build() returning a
  typed *helmv2.HelmRelease; InCluster=false wires up the kubeConfig
  secretRef using ClusterName; ClusterName is always required for
  values templating regardless of target
- EnsureOCIRepository / DeleteOCIRepository using typed sourcev1beta2
- IsHelmReleaseReady and IsAppOrHelmReleaseReady wait conditions
- Registers helmv2 and sourcev1beta2 schemes in init() so importing the
  package is sufficient for cr.Client operations
- Adds sourcev1beta2.AddToScheme to pkg/client for belt-and-suspenders

New dependency: github.com/fluxcd/source-controller/api v1.8.2
