### PR TITLE
Add architect context to tests job to fix nancy rate limits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ workflows:
   test:
     jobs:
       - tests:
+          context: architect
           filters:
             tags:
               only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - run:
           name: "Install nancy"
           command: |
-            curl -sSL -o nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.0.46/nancy-v1.0.46-linux-amd64
+            curl -sSL -o nancy https://github.com/sonatype-nexus-community/nancy/releases/download/v1.2.0/nancy-v1.2.0-linux-amd64
             chmod +x nancy
             sudo cp nancy /usr/local/bin/nancy
       - architect/go-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add `architect` context to the `tests` job so nancy authenticates against Sonatype OSS Index and avoids anonymous rate limits.
+
 ## [4.2.0] - 2026-04-15
 
 ### Added


### PR DESCRIPTION
Sonatype changed their OSS Index limits, causing nancy to fail with rate-limit errors when running unauthenticated. The `architect` context provides credentials so nancy authenticates and avoids the anonymous limit.

Failing pipeline: https://app.circleci.com/pipelines/github/giantswarm/clustertest/2459/workflows/eab3925b-bf0d-4a83-b9a7-a69e20928274/jobs/2466