### PR TITLE
feat(helmrelease): add service account name support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- HelmRelease: Add service account name support.
+
+### Fixed
+
+- HelmRelease: Disable `createNamespace` when running in-cluster.
+
 ### Changed
 
 - Go: Update dependencies.

--- a/pkg/helmrelease/helmrelease.go
+++ b/pkg/helmrelease/helmrelease.go
@@ -155,7 +155,7 @@ func (h *HelmRelease) Build() (*helmv2.HelmRelease, error) {
 				Name: h.OCIRepoName,
 			},
 			Install: &helmv2.Install{
-				CreateNamespace: true,
+				CreateNamespace: !h.InCluster,
 				Remediation: &helmv2.InstallRemediation{
 					Retries: 5,
 				},

--- a/pkg/helmrelease/helmrelease.go
+++ b/pkg/helmrelease/helmrelease.go
@@ -46,6 +46,8 @@ type HelmRelease struct {
 	// InCluster controls the deployment target: true = management cluster (no kubeConfig),
 	// false = workload cluster (kubeConfig from ClusterName secret).
 	InCluster bool
+	// ServiceAccountName is the Kubernetes service account to impersonate when reconciling.
+	ServiceAccountName string
 }
 
 // New creates a new HelmRelease builder for the given chart.
@@ -95,6 +97,12 @@ func (h *HelmRelease) WithClusterName(clusterName string) *HelmRelease {
 // or a workload cluster (false, default).
 func (h *HelmRelease) WithInCluster(inCluster bool) *HelmRelease {
 	h.InCluster = inCluster
+	return h
+}
+
+// WithServiceAccountName sets the Kubernetes service account to impersonate when reconciling.
+func (h *HelmRelease) WithServiceAccountName(sa string) *HelmRelease {
+	h.ServiceAccountName = sa
 	return h
 }
 
@@ -154,6 +162,10 @@ func (h *HelmRelease) Build() (*helmv2.HelmRelease, error) {
 			},
 			Values: rawValues,
 		},
+	}
+
+	if h.ServiceAccountName != "" {
+		hr.Spec.ServiceAccountName = h.ServiceAccountName
 	}
 
 	if !h.InCluster {


### PR DESCRIPTION
## Summary

- Adds `ServiceAccountName` field to the `HelmRelease` builder struct
- Adds `WithServiceAccountName(sa string)` fluent setter
- Wires the value into `spec.serviceAccountName` in `Build()` when non-empty

## Test plan

- [ ] Verify `WithServiceAccountName` sets `spec.serviceAccountName` on the built CR
- [ ] Verify omitting it leaves `spec.serviceAccountName` empty